### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -2,12 +2,109 @@ name: Build TUI Binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version. Defaults to package.json."
+        required: false
+        type: string
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
+
+concurrency: release-${{ github.ref }}
+
+permissions:
+  contents: read
+
+env:
+  AGENTSWARM_CLI_VERSION: 1.4.32
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.release.outputs.release_version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      is_prerelease: ${{ steps.release.outputs.is_prerelease }}
+      npm_tag: ${{ steps.release.outputs.npm_tag }}
+      target_commitish: ${{ steps.release.outputs.target_commitish }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve release version
+        id: release
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "Manual releases must run from main. Current ref: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+          package_version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').packages[''].version")"
+          python_version="$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+
+          input_version="$INPUT_VERSION"
+          input_version="${input_version#v}"
+          release_version="${input_version:-$package_version}"
+
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release version must be semver X.Y.Z or X.Y.Z-prerelease, got: $release_version" >&2
+            exit 1
+          fi
+
+          if [[ "$package_version" != "$release_version" ]]; then
+            echo "package.json version ($package_version) must match release version ($release_version)." >&2
+            exit 1
+          fi
+
+          if [[ "$lock_version" != "$release_version" ]]; then
+            echo "package-lock.json version ($lock_version) must match release version ($release_version)." >&2
+            exit 1
+          fi
+
+          if [[ "$python_version" != "$release_version" ]]; then
+            echo "pyproject.toml version ($python_version) must match release version ($release_version)." >&2
+            exit 1
+          fi
+
+          release_tag="v$release_version"
+          is_prerelease=false
+          npm_tag=latest
+          if [[ "$release_version" == *-* ]]; then
+            is_prerelease=true
+            npm_tag="${release_version#*-}"
+            npm_tag="${npm_tag%%.*}"
+          fi
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" != "$release_tag" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package version $release_version." >&2
+            exit 1
+          fi
+
+          {
+            echo "release_version=$release_version"
+            echo "release_tag=$release_tag"
+            echo "is_prerelease=$is_prerelease"
+            echo "npm_tag=$npm_tag"
+            echo "target_commitish=$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     strategy:
       matrix:
         include:
@@ -28,14 +125,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: ArtemShatokhin/agentswarm-cli
-          ref: aaaa4557178e54ad88ec839345d411cf7cace76e
+          repository: VRSEN/agentswarm-cli
+          ref: v${{ env.AGENTSWARM_CLI_VERSION }}
           path: agentswarm-cli
 
       - uses: oven-sh/setup-bun@v2
         with:
-          # Bun 1.3.12 produces a darwin-arm64 binary that exits 137 during smoke test.
-          bun-version: "1.3.11"
+          bun-version: "1.3.13"
 
       - name: Install dependencies
         working-directory: agentswarm-cli
@@ -43,6 +139,9 @@ jobs:
 
       - name: Build binary
         working-directory: agentswarm-cli/packages/opencode
+        env:
+          OPENCODE_CHANNEL: latest
+          OPENCODE_VERSION: ${{ env.AGENTSWARM_CLI_VERSION }}
         run: bun run script/build.ts --single --skip-install
 
       - name: Rename binary (Unix)
@@ -66,7 +165,10 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: build
+    needs:
+      - prepare
+      - build
+    if: github.repository == 'VRSEN/OpenSwarm'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -77,7 +179,114 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+          TARGET_COMMITISH: ${{ needs.prepare.outputs.target_commitish }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t files < <(find dist -type f | sort)
+          if (( ${#files[@]} == 0 )); then
+            echo "No release assets found in dist/." >&2
+            exit 1
+          fi
+
+          create_flags=(--draft --generate-notes --target "$TARGET_COMMITISH" --title "$RELEASE_TAG")
+          edit_flags=(--draft=false)
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            create_flags+=(--prerelease --latest=false)
+            edit_flags+=(--prerelease)
+          else
+            create_flags+=(--latest)
+            edit_flags+=(--latest)
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          else
+            gh release create "$RELEASE_TAG" "${files[@]}" "${create_flags[@]}"
+          fi
+
+          gh release edit "$RELEASE_TAG" "${edit_flags[@]}"
+
+  publish-npm:
+    needs:
+      - prepare
+      - release
+    if: github.repository == 'VRSEN/OpenSwarm'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_CONFIG_PROVENANCE: false
+      NPM_TAG: ${{ needs.prepare.outputs.npm_tag }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
         with:
-          files: dist/*
-          generate_release_notes: true
+          ref: ${{ needs.prepare.outputs.release_tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate release metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
+            echo "NPM_TOKEN is required to publish to npm." >&2
+            exit 1
+          fi
+
+          if [[ "$RELEASE_TAG" != "v$RELEASE_VERSION" ]]; then
+            echo "Release tag ($RELEASE_TAG) must match release version ($RELEASE_VERSION)." >&2
+            exit 1
+          fi
+
+          package_version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').packages[''].version")"
+          python_version="$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+
+          if [[ "$package_version" != "$RELEASE_VERSION" || "$lock_version" != "$RELEASE_VERSION" || "$python_version" != "$RELEASE_VERSION" ]]; then
+            echo "Release tag, package.json, package-lock.json, and pyproject.toml versions must match." >&2
+            echo "tag=$RELEASE_VERSION package=$package_version lock=$lock_version pyproject=$python_version" >&2
+            exit 1
+          fi
+
+          mapfile -t assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | sort)
+          required_assets=(
+            agentswarm-darwin-arm64
+            agentswarm-darwin-x64
+            agentswarm-linux-x64
+            agentswarm-windows-x64.exe
+          )
+
+          for required in "${required_assets[@]}"; do
+            if ! printf '%s\n' "${assets[@]}" | grep -Fxq "$required"; then
+              echo "Release $RELEASE_TAG is missing required asset: $required" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish npm package
+        run: npm publish --access public --tag "$NPM_TAG"

--- a/.github/workflows/publish-npm-on-release.yml
+++ b/.github/workflows/publish-npm-on-release.yml
@@ -1,0 +1,96 @@
+name: Fallback Publish npm on Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.repository == 'VRSEN/OpenSwarm'
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_CONFIG_PROVENANCE: false
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate release metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
+            echo "NPM_TOKEN is required to publish to npm." >&2
+            exit 1
+          fi
+
+          release_version="${RELEASE_TAG#v}"
+          npm_tag=latest
+          is_prerelease=false
+          if [[ "$release_version" == *-* ]]; then
+            is_prerelease=true
+            npm_tag="${release_version#*-}"
+            npm_tag="${npm_tag%%.*}"
+          fi
+          if [[ "$is_prerelease" != "${{ github.event.release.prerelease }}" ]]; then
+            echo "Release prerelease flag must match semver prerelease suffix." >&2
+            echo "tag=$RELEASE_TAG github_prerelease=${{ github.event.release.prerelease }}" >&2
+            exit 1
+          fi
+          package_version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').packages[''].version")"
+          python_version="$(python3 - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Release tag must be vX.Y.Z or vX.Y.Z-prerelease, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          if [[ "$package_version" != "$release_version" || "$lock_version" != "$release_version" || "$python_version" != "$release_version" ]]; then
+            echo "Release tag, package.json, package-lock.json, and pyproject.toml versions must match." >&2
+            echo "tag=$release_version package=$package_version lock=$lock_version pyproject=$python_version" >&2
+            exit 1
+          fi
+
+          mapfile -t assets < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | sort)
+          required_assets=(
+            agentswarm-darwin-arm64
+            agentswarm-darwin-x64
+            agentswarm-linux-x64
+            agentswarm-windows-x64.exe
+          )
+
+          for required in "${required_assets[@]}"; do
+            if ! printf '%s\n' "${assets[@]}" | grep -Fxq "$required"; then
+              echo "Release $RELEASE_TAG is missing required asset: $required" >&2
+              exit 1
+            fi
+          done
+
+          echo "NPM_TAG=$npm_tag" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish npm package
+        run: npm publish --access public --tag "$NPM_TAG"

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -21,20 +21,23 @@ jobs:
           python-version: '3.12'
       - uses: actions/checkout@v4
         with:
-          repository: ArtemShatokhin/agentswarm-cli
-          ref: aaaa4557178e54ad88ec839345d411cf7cace76e
+          repository: VRSEN/agentswarm-cli
+          ref: v1.4.32
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.13"
       - name: Smoke-test pinned custom macOS TUI build
         shell: bash
         working-directory: agentswarm-cli
+        env:
+          OPENCODE_CHANNEL: latest
+          OPENCODE_VERSION: 1.4.32
         run: |
           bun install
           cd packages/opencode
           bun run script/build.ts --single --skip-install
-          ./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version
+          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.4.32"
       - name: Test startup
         shell: bash
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,33 @@
+# Release Workflow
+
+OpenSwarm releases use one normal path: `Build TUI Binaries` builds the required assets, publishes the GitHub Release, then publishes `@vrsen/openswarm` to npm in the same workflow run. The release tag, npm package version, lockfile version, and Python project metadata must use the same semver version.
+
+## Release Inputs
+
+- Source version: `X.Y.Z` or `X.Y.Z-prerelease` in `package.json`
+- Matching metadata: `package-lock.json` and `pyproject.toml`
+- GitHub tag format: `vX.Y.Z` or `vX.Y.Z-prerelease`
+- GitHub release assets:
+  - `agentswarm-darwin-arm64`
+  - `agentswarm-darwin-x64`
+  - `agentswarm-linux-x64`
+  - `agentswarm-windows-x64.exe`
+
+## Release Steps
+
+1. Bump `package.json`, `package-lock.json`, and `pyproject.toml` to the same version.
+2. Merge the version bump to `main`.
+3. Run the `Build TUI Binaries` workflow from the `main` branch in GitHub Actions. Leave `version` blank to use `package.json`, or pass the exact version without the `v` prefix.
+4. Confirm the workflow creates the matching GitHub Release with all required binary assets.
+5. Let the downstream npm publish job in the same workflow publish `@vrsen/openswarm` from the release tag. Stable versions publish to `latest`; prereleases publish to the prerelease label such as `rc`.
+
+Pushing a matching version tag also runs the binary release workflow. The manual workflow is the preferred path because it builds assets, publishes the GitHub Release, and publishes npm in one run.
+
+GitHub releases created with `${{ github.token }}` do not start separate `on: release` workflows. `Fallback Publish npm on Release` exists only for releases that are published manually, externally, or through an API token that can trigger release workflows. It is not the normal release path.
+
+## Release Gates
+
+- The binary release workflow fails if the tag/input version does not match `package.json`, `package-lock.json`, and `pyproject.toml`.
+- The npm publish job fails if `NPM_TOKEN` is missing, versions do not match, or the GitHub Release is missing any required TUI binary asset.
+- The fallback npm publish workflow runs the same key checks for manually or externally published releases, including prereleases.
+- The npm package uses `publishConfig.access=public` so scoped publishes do not depend on CLI flags alone.

--- a/bin/openswarm
+++ b/bin/openswarm
@@ -10,6 +10,7 @@ const path = require('path')
 
 const scriptPath = fs.realpathSync(__filename)
 const packageDir = path.dirname(path.dirname(scriptPath))
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'))
 
 function resolveAgentswarm(startDir) {
   let current = startDir
@@ -35,7 +36,7 @@ function getBinaryName() {
 function getDownloadUrl(binaryName) {
   const explicit = process.env.OPENSWARM_TUI_URL && process.env.OPENSWARM_TUI_URL.trim()
   if (explicit) return explicit
-  return `https://github.com/VRSEN/OpenSwarm/releases/latest/download/${binaryName}`
+  return `https://github.com/VRSEN/OpenSwarm/releases/download/v${packageJson.version}/${binaryName}`
 }
 
 function resolveCustomBinary(binaryPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "0.1.27",
+    "version": "1.0.1-rc.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "0.1.27",
+            "version": "1.0.1-rc.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "latest",
+                "@vrsen/agentswarm": "1.4.32",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -496,21 +496,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.31.tgz",
-            "integrity": "sha512-X8rNuc+x6QME13GcdeM7ItYLuv4roQcGlTqrmCWTqm8Pb9cpKfqBsh60NG0nfcKyde3KuMfLYlctU7Z94D5vtQ==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.32.tgz",
+            "integrity": "sha512-K2ojt56lThrQZIYtkCeHnShnIbnygwx8U79vftpZNMugYWyB36KvXIww7DsOJ9RzV4+gmWXX3MPlmAC8fSEcqA==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.31"
+                "agentswarm-cli": "1.4.32"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.31.tgz",
-            "integrity": "sha512-Tu3b/gE/j/l9QZ9Zo3wTNuKQzhR9HC2YZY/6KWJ7btrITx9tgsbrFhvbZb1tTUpc7UOiUR9lpYtsWZK8blEW+w==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.32.tgz",
+            "integrity": "sha512-UgPjM0JfAwawHbN26q/4/xI9fqDu3a4z6Rhs3iHsR7FbAtdyJ+UnAPYUJeG6U4MhfhjHgu4u5T3URNKRnjBugg==",
             "cpu": [
                 "arm64"
             ],
@@ -520,9 +520,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.31.tgz",
-            "integrity": "sha512-lifFU4OQfNE31A2T4TpPqP7eujTOqdJWZYkzFQUPwY9Z7UqASoDEGLCkACyHtIQUBwjOr+b8/IJwCynbS6VHSQ==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.32.tgz",
+            "integrity": "sha512-1qoDB6ooFHx/MGNLsxJq+lIrerk5sc/x5r8s0ym8TDydEJi6Xa7kfx7KFWuOTMxW2kIgH5PHkfNk25RhpUyDJA==",
             "cpu": [
                 "x64"
             ],
@@ -532,9 +532,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.31.tgz",
-            "integrity": "sha512-im1PPYlPjUJ2yVCKwxXRkCnjxb2Y+HSYY2xdhGqMXzESDY1ewgTzg1u9U7oOE+8VD9VvPgz4WvE+ILKahck53w==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.32.tgz",
+            "integrity": "sha512-Wr8vYhSO356gPFBtLFWt/7DHazVIy9bloemD+hbJqsbLugYUwf0g/LvHwVtdkQXt0enl752aZfMO2y+0EgxKHw==",
             "cpu": [
                 "x64"
             ],
@@ -544,9 +544,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.31.tgz",
-            "integrity": "sha512-IRqUt4Nt/3WSrmLyPScZ4IY+XCd1qwUTkS3qGuoqvPhQWw38Zfqn7rKLtPoMAVXB6tgMUVe2+LPi/ys1SNPBQQ==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.32.tgz",
+            "integrity": "sha512-o5XXcPOVo1UcCxZF2dbBBixF3QjG3PzEtlPuqI/hqwKoh1QRUVhyYO7kB3WpxUI2NJJOxV4H1wSd7xZZxtDckg==",
             "cpu": [
                 "arm64"
             ],
@@ -556,9 +556,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.31.tgz",
-            "integrity": "sha512-UP6umsBs2nxZH7Y+buG4FGE54NYEx9ATMB60SNJSVfXENW+k4mppqJA9sdF0BkoCmR1ZVOnLTB4os1GQQKtp+w==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.32.tgz",
+            "integrity": "sha512-LlbTZ0r7eiaz84UaHQkiLQqpD6LUNSdVD5RDgsolYc7ysMaQMDzablsp54aRWh14cUbQCsq9vNAFY4zl2tlh8A==",
             "cpu": [
                 "arm64"
             ],
@@ -568,9 +568,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.31.tgz",
-            "integrity": "sha512-5D1A2B7V8vsufIlEvFxOnpfJBd2lXbz0rfOMKHPTBseDQmCC8g5CZdiJseI1ijnsBeVIl77SiPU7KN6c4dGldw==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.32.tgz",
+            "integrity": "sha512-24yFcntmcZzHP5bTG7ieOXip6YdO7RLf0eLhiDbPrAZlHk5Efkdt5Upn268pCHZBZo4LwkQOaeka8hbq0QP1YA==",
             "cpu": [
                 "x64"
             ],
@@ -580,9 +580,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.31.tgz",
-            "integrity": "sha512-/Dr8O7f+l3X7/cSpJ7opzFtXtllB9Gu6+FmOMpYqocfHDXUL6YbqTxpiHgwQjJGY9yQJ4q3FCEBHRcRLAoBnMA==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.32.tgz",
+            "integrity": "sha512-ToyNqXXn1D5dQM9DhvUqoNpbruOCBUXGP7zAOINdm0bG8ENeOGx1nBlwCclU+zWnNzb8EYlOPghLUH5To3bz6g==",
             "cpu": [
                 "x64"
             ],
@@ -592,9 +592,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.31.tgz",
-            "integrity": "sha512-vAss2ilfXFsDQcAsaGW0jkfL9vGGjXBk03shKmbbwsyBDjHJ7IrZqR5jlYeFIoFqgd5VMnhVcyx1NkqicpR07g==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.32.tgz",
+            "integrity": "sha512-RDSZOcjdEBNVun/FlZswm8t+I1YuYHLmfSvFbQqdgTIi4WD4Fg5JPbRx4IunHz2iISuPm2lodhO1xrRmLgapnw==",
             "cpu": [
                 "x64"
             ],
@@ -604,9 +604,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.31.tgz",
-            "integrity": "sha512-7fNBkrOd42CL7BK10QZOprBOgfaUNEmLvSTt4LyWA6OPUeq7iBZbRwgZbzduzh2pZuHmdNAqwpkc7vqXrv6NYw==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.32.tgz",
+            "integrity": "sha512-RbxX22VXBlcl4L93JKuazDTNn9tcsKYOHKwydoaBtRVEG0pf/m4xmNQ1M5evAbNUBSHDIHTL/lqSuEsL98Mwgg==",
             "cpu": [
                 "x64"
             ],
@@ -616,9 +616,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.31.tgz",
-            "integrity": "sha512-Ms8mCPBXN3hcy8/6CaKio7U/+pkrb0eAUuB+7gLJBNXJViVSv+rj+dOeIaYJZEYi+xy4n1QxlBagGlMlD7Synw==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.32.tgz",
+            "integrity": "sha512-pcMYZUEdnNlric95+Fu9FC/DKtjK/LiTjeSOxO8HoZHo260mVczhMnkEcBlAOojfimHft1VmasSiLZGIpzNsLg==",
             "cpu": [
                 "arm64"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.31.tgz",
-            "integrity": "sha512-BNwpSy4rtStrEN+lEph4qmC0lYdpGVk5okN5QUBQ67NqCxBRDh1ZnDHmEuCuJXaxkLuEieLPhVfpLuwhaX3eyg==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.32.tgz",
+            "integrity": "sha512-QjH+ZRrjTFPyL00k1J7L1MuIIbsKYRbKXGrMjX8vV7glQk4AXRpQtl+TLcpPRwv2TV16m2rEAId77erY6ebq6w==",
             "cpu": [
                 "x64"
             ],
@@ -640,9 +640,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.31.tgz",
-            "integrity": "sha512-0lKowtyH7SODU4YvXZsaQoUvDgfJNC/eV1r01lWQRADtRqavdcElXLX23zTn3oj24kog/VsZky2D4KMGbQfA9Q==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.32.tgz",
+            "integrity": "sha512-4OqxP7qiPusTXBdaAMxaYFpokTkkxDsGF40Wd6ZiTYGwqQHm7m0SngFic+M7lpFsToLj+v1A+CBp5bNqywuOSA==",
             "cpu": [
                 "x64"
             ],
@@ -667,27 +667,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.31",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.31.tgz",
-            "integrity": "sha512-qIJ8ibpHuUIfLdL0bByg++DHPcAu9rH73aIzLQIVKwSK2vd0ZMOZ+Y1gHjJ1DCZMABP0vRu6FVPuM38sAylMPw==",
+            "version": "1.4.32",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.32.tgz",
+            "integrity": "sha512-BrEq2oLaCZp57WoXNpjnk87KeEazdxp7+AoZLwGeEyGigIhRrOLJoVEvfwHC3fRMV6OY+3Y1lpR083pTjMShNg==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.31",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.31",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.31",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.31",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.31",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.31",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.31"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.32",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.32",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.32",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.32",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.32",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.32",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.32"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "0.1.27",
+    "version": "1.0.1-rc.1",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
+    "publishConfig": {
+        "access": "public"
+    },
     "bin": {
         "openswarm": "./bin/openswarm"
     },
@@ -33,7 +36,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "latest",
+        "@vrsen/agentswarm": "1.4.32",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "0.1.0"
+version = "1.0.1-rc.1"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"
 dependencies = [
-    "agency-swarm[fastapi,jupyter,litellm]>=1.9.7",
+    "agency-swarm[fastapi,jupyter,litellm]>=1.9.8",
     "questionary>=2.0.0",
     "python-dotenv",
     "rich",


### PR DESCRIPTION
## Summary
- build OpenSwarm TUI binaries from `VRSEN/agentswarm-cli@v1.4.32`
- publish GitHub Releases and npm packages from one workflow, including `1.0.1-rc.1` prereleases under the `rc` npm tag
- pin `@vrsen/agentswarm` to `1.4.32` and require `agency-swarm>=1.9.8`
- make the launcher download TUI assets from its own package version release instead of `latest`
- document the release path in `RELEASE.md`

## Checks
- YAML parsed for all GitHub workflow files
- `git diff --check`
- npm and Python metadata checks
- `npm ci --ignore-scripts`
- `npm pack --dry-run`
- local package install smoke for fallback and custom TUI paths
- local source build from `VRSEN/agentswarm-cli@v1.4.32` returned `1.4.32`
- Codex review with GPT-5.5 high reasoning: no actionable issues after fixes

## Notes
- This prepares the `1.0.1-rc.1` prerelease path. It does not publish a stable OpenSwarm release.
