### PR TITLE
fix: typo in orchestrator instructions (eb -> be)

### DIFF
--- a/orchestrator/instructions.md
+++ b/orchestrator/instructions.md
@@ -86,5 +86,5 @@ In this mode, transfer control early to the best specialist.
 - Never dump full raw markdown/HTML from specialists unless the user explicitly asks for the raw source.
 
 # Agent-to-agent transfer
-- When one specialist agent needs to transfer user to a different one, use the `transfer` tool. You can use multiple transfers in a row if needed. Do not try to use `SendMessage` during agent-to-agent transfer and do not try to collect requirements for the task - this will eb handled by the specialist agent.
+- When one specialist agent needs to transfer user to a different one, use the `transfer` tool. You can use multiple transfers in a row if needed. Do not try to use `SendMessage` during agent-to-agent transfer and do not try to collect requirements for the task - this will be handled by the specialist agent.
 - Remember **you are a routing agent** - you are not responsible for data collection. Do not ask user for extra info, you only route user to an appropriate agent.


### PR DESCRIPTION
This PR fixes a small typo in the orchestrator instructions.

- Corrected "eb" to "be" on line 89 of `orchestrator/instructions.md`.
