### PR TITLE
Update OpenSwarm README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@
 
 Create polished slide decks, research reports, data visualizations, documents, images, and videos — all from a single prompt in your terminal. No platform, no UI, no setup hassles.
 
-✨ **One prompt → Complete deliverables**
-🎯 **8 specialized agents working together**
-⚡ **Install in 30 seconds, running in 60**
-🔧 **100% customizable and forkable**
+✨ **One prompt → Complete deliverables**<br>
+🎯 **8 specialized agents working together**<br>
+⚡ **Install in 30 seconds, running in 60**<br>
+🔧 **100% customizable and forkable**<br>
 
-Built on [Agency Swarm](https://github.com/VRSEN/agency-swarm) — the framework powering real AI agencies.
+Built on [Agency Swarm](https://github.com/VRSEN/agency-swarm) — the framework powering real AI swarms.<br>
+Terminal UI: [AgentSwarm](https://github.com/VRSEN/agentswarm-cli), an OpenCode-based TUI customized for Agency Swarm.
+
+<a href="https://www.producthunt.com/products/openswarm?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-openswarm" target="_blank" rel="noopener noreferrer"><img alt="OpenSwarm - Claude Code for everything except coding | Product Hunt" width="200" height="43" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1141784&amp;theme=light&amp;t=1778266049404"></a>
 
 ---
 
@@ -151,7 +154,19 @@ python server.py           # Runs on localhost:8080
 
 - **Watch the full demo:** [YouTube video →](https://youtu.be/c5DdXzqaeVU?si=rM2CNaZ8qVwMvqmz)
 - **Multi-agent framework:** [Agency Swarm](https://github.com/VRSEN/agency-swarm)
+- **Terminal UI for Agency Swarm:** [AgentSwarm](https://github.com/VRSEN/agentswarm-cli) (OpenCode-based TUI)
 - **External integrations:** [Composio](https://composio.dev)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=VRSEN/OpenSwarm&type=date&legend=top-left)](https://www.star-history.com/#VRSEN/OpenSwarm&type=date&legend=top-left)
+
+---
+
+## 👥 Team
+
+- **Artemii Shatokhin** — Built the core OpenSwarm agent team: the specialist agents, orchestration layer, shared tools, and runtime integrations. ([GitHub](https://github.com/ArtemShatokhin))
+- **Nick Bobrowski** — Built the foundation OpenSwarm builds on: Agency Swarm and the AgentSwarm CLI/TUI, an OpenCode-based terminal experience customized for Agency Swarm. ([GitHub](https://github.com/nicko-ai))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Create polished slide decks, research reports, data visualizations, documents, i
 🔧 **100% customizable and forkable**<br>
 
 Built on [Agency Swarm](https://github.com/VRSEN/agency-swarm) — the framework powering real AI swarms.<br>
-Terminal UI: [AgentSwarm](https://github.com/VRSEN/agentswarm-cli), an OpenCode-based TUI customized for Agency Swarm.
 
 <a href="https://www.producthunt.com/products/openswarm?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-openswarm" target="_blank" rel="noopener noreferrer"><img alt="OpenSwarm - Claude Code for everything except coding | Product Hunt" width="200" height="43" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1141784&amp;theme=light&amp;t=1778266049404"></a>
 


### PR DESCRIPTION
## Summary
- add Product Hunt and Star History proof points to the README
- link AgentSwarm as the OpenCode-based TUI customized for Agency Swarm
- update Agency Swarm wording from AI agencies to AI swarms
- add Team attribution for Artemii and Nick, including Nick's Agency Swarm / AgentSwarm foundation work
- adjust the first-screen README layout so the proof badge does not compete with the hero image

## Checks
- README-only diff: `README.md`
- squashed to one commit: `ba3b1cbd5 Update OpenSwarm README`
- `git diff --check origin/main..HEAD`
- confirmed `USER_WORDS.md` is ignored and not committed