### PR TITLE
Regenerate package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
+                "@vrsen/agentswarm": "latest",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -21,6 +22,9 @@
             },
             "bin": {
                 "openswarm": "bin/openswarm"
+            },
+            "devDependencies": {
+                "turbo": "^2.9.6"
             },
             "engines": {
                 "node": ">=18.0.0",
@@ -398,6 +402,90 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@turbo/darwin-64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.10.tgz",
+            "integrity": "sha512-5BVJnes8/zMPydF8ktfBBWqCCpUeWVxwZ6avYHRqLzk2PuTAsLz0TlaKdDe1nk1cz3/o0c+7CEf6zqNXdB2N7Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/darwin-arm64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.9.10.tgz",
+            "integrity": "sha512-MwaJl+vsxlkkDJYWN87GWKYD64kOvZFFlrDtGmCDeEx/488Kola5TVgS0VQkEUwnbDPjaDIB7kBMIzdzJRElbg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@turbo/linux-64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.10.tgz",
+            "integrity": "sha512-HWrCKR+kUicEf4awj1EVRh5LI2hiDncpWZSXqhVj+wQT3SolBSXqXiSPYHgdh6hkmyfvz75Ex/+axXGcgQGdeA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/linux-arm64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.10.tgz",
+            "integrity": "sha512-edJINoZcDn4g1zkOZHFrGtLX0EWTryoNJSlZK5SEVux4hITT6hTCzugVGtOUmdI+PuJ/xRRL3jKGa+JgjSoq5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@turbo/windows-64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.10.tgz",
+            "integrity": "sha512-rkASn89ATUtSyKvhGaWSyqVHBwtqFEUV1rFNKCtthSoix0T/kUHLJDKpepE/Wh6CtSnhxAfsY8cODtevD/hR7A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@turbo/windows-arm64": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.10.tgz",
+            "integrity": "sha512-cblXqub7uABXKNMzvPB1IyOuSQpeMo7zZHSREB2C0mtIVn4lUSd2CfaGBtOrDqmkC9dsan3itxY4IejChQvfpg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@types/node": {
             "version": "18.19.130",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -406,6 +494,162 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@vrsen/agentswarm": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.31.tgz",
+            "integrity": "sha512-X8rNuc+x6QME13GcdeM7ItYLuv4roQcGlTqrmCWTqm8Pb9cpKfqBsh60NG0nfcKyde3KuMfLYlctU7Z94D5vtQ==",
+            "license": "MIT",
+            "dependencies": {
+                "agentswarm-cli": "1.4.31"
+            },
+            "bin": {
+                "agentswarm": "bin/agentswarm"
+            }
+        },
+        "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.31.tgz",
+            "integrity": "sha512-Tu3b/gE/j/l9QZ9Zo3wTNuKQzhR9HC2YZY/6KWJ7btrITx9tgsbrFhvbZb1tTUpc7UOiUR9lpYtsWZK8blEW+w==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.31.tgz",
+            "integrity": "sha512-lifFU4OQfNE31A2T4TpPqP7eujTOqdJWZYkzFQUPwY9Z7UqASoDEGLCkACyHtIQUBwjOr+b8/IJwCynbS6VHSQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.31.tgz",
+            "integrity": "sha512-im1PPYlPjUJ2yVCKwxXRkCnjxb2Y+HSYY2xdhGqMXzESDY1ewgTzg1u9U7oOE+8VD9VvPgz4WvE+ILKahck53w==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.31.tgz",
+            "integrity": "sha512-IRqUt4Nt/3WSrmLyPScZ4IY+XCd1qwUTkS3qGuoqvPhQWw38Zfqn7rKLtPoMAVXB6tgMUVe2+LPi/ys1SNPBQQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.31.tgz",
+            "integrity": "sha512-UP6umsBs2nxZH7Y+buG4FGE54NYEx9ATMB60SNJSVfXENW+k4mppqJA9sdF0BkoCmR1ZVOnLTB4os1GQQKtp+w==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-x64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.31.tgz",
+            "integrity": "sha512-5D1A2B7V8vsufIlEvFxOnpfJBd2lXbz0rfOMKHPTBseDQmCC8g5CZdiJseI1ijnsBeVIl77SiPU7KN6c4dGldw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.31.tgz",
+            "integrity": "sha512-/Dr8O7f+l3X7/cSpJ7opzFtXtllB9Gu6+FmOMpYqocfHDXUL6YbqTxpiHgwQjJGY9yQJ4q3FCEBHRcRLAoBnMA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.31.tgz",
+            "integrity": "sha512-vAss2ilfXFsDQcAsaGW0jkfL9vGGjXBk03shKmbbwsyBDjHJ7IrZqR5jlYeFIoFqgd5VMnhVcyx1NkqicpR07g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.31.tgz",
+            "integrity": "sha512-7fNBkrOd42CL7BK10QZOprBOgfaUNEmLvSTt4LyWA6OPUeq7iBZbRwgZbzduzh2pZuHmdNAqwpkc7vqXrv6NYw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.31.tgz",
+            "integrity": "sha512-Ms8mCPBXN3hcy8/6CaKio7U/+pkrb0eAUuB+7gLJBNXJViVSv+rj+dOeIaYJZEYi+xy4n1QxlBagGlMlD7Synw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-windows-x64": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.31.tgz",
+            "integrity": "sha512-BNwpSy4rtStrEN+lEph4qmC0lYdpGVk5okN5QUBQ67NqCxBRDh1ZnDHmEuCuJXaxkLuEieLPhVfpLuwhaX3eyg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.31.tgz",
+            "integrity": "sha512-0lKowtyH7SODU4YvXZsaQoUvDgfJNC/eV1r01lWQRADtRqavdcElXLX23zTn3oj24kog/VsZky2D4KMGbQfA9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@xmldom/xmldom": {
             "version": "0.8.11",
@@ -421,6 +665,30 @@
             "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
             "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/agentswarm-cli": {
+            "version": "1.4.31",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.31.tgz",
+            "integrity": "sha512-qIJ8ibpHuUIfLdL0bByg++DHPcAu9rH73aIzLQIVKwSK2vd0ZMOZ+Y1gHjJ1DCZMABP0vRu6FVPuM38sAylMPw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "agentswarm": "bin/agentswarm"
+            },
+            "optionalDependencies": {
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.31",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.31",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.31",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.31",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.31",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.31",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.31"
+            }
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -1487,6 +1755,24 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD",
             "optional": true
+        },
+        "node_modules/turbo": {
+            "version": "2.9.10",
+            "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.10.tgz",
+            "integrity": "sha512-YBLeNT0wLoysGgQEkvBWE2GA1liGGZ1j13wa7xHTwELJx4ZhM+c2szeXj6wUOUGO86BmyhY0Q/ELWwU3WDXzZA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "turbo": "bin/turbo"
+            },
+            "optionalDependencies": {
+                "@turbo/darwin-64": "2.9.10",
+                "@turbo/darwin-arm64": "2.9.10",
+                "@turbo/linux-64": "2.9.10",
+                "@turbo/linux-arm64": "2.9.10",
+                "@turbo/windows-64": "2.9.10",
+                "@turbo/windows-arm64": "2.9.10"
+            }
         },
         "node_modules/undici-types": {
             "version": "5.26.5",


### PR DESCRIPTION
## Summary
- Updates package-lock.json so it matches package.json.
- Adds the missing locked versions for @vrsen/agentswarm, turbo, and the packages they install.

## Why this is needed
package.json says the project needs these packages, but package-lock.json did not include them. That can make npm ci fail in CI, during releases, or on a fresh checkout. It can also let different machines install different package versions.

Updating the lockfile makes npm ci use the same package versions everywhere.

## Check
- npm ci --dry-run --ignore-scripts

Note: npm install reported 3 existing audit findings.