### PR TITLE
Fix Anthropic Claude integration via LiteLLM model routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,29 +11,45 @@
 # OpenAI — set this if using OpenAI as your primary provider.
 OPENAI_API_KEY=
 
-# Anthropic Claude — set this if using Anthropic as your primary provider.
+# Anthropic Claude — standard pay-per-token API key.
+# Get one at https://console.anthropic.com/settings/keys
+# Format: sk-ant-api03-...
 #
-# Two kinds of tokens are accepted in this single variable:
-#   1. Standard API key from https://console.anthropic.com/settings/keys
-#      Format: sk-ant-api03-...
-#   2. Claude Pro / Max / Claude Code subscription OAuth token.
-#      Generate one with the Claude Code CLI:
-#          claude setup-token
-#      Format: sk-ant-oat01-...
-#      Using an OAuth token routes calls through your Claude subscription
-#      instead of pay-per-token API billing.
+# NOTE: Claude Pro / Max / Claude Code subscription OAuth tokens
+# (sk-ant-oat01-...) are NOT accepted here directly — LiteLLM does
+# not implement the OAuth header protocol. To use a subscription,
+# run a local router (see "Local LLM router" section below) and
+# leave this blank.
 ANTHROPIC_API_KEY=
 
 # Google Gemini — set this if using Google as your primary provider.
 GOOGLE_API_KEY=
 
 
+# ── Local LLM router (use Claude Code subscription) ──
+#
+# Route every model call through a local router (e.g. claude-code-router,
+# 9router, ccproxy) that authenticates with your Claude Pro/Max/Claude Code
+# subscription. The router exposes an OpenAI-compatible endpoint and handles
+# the OAuth token + required headers internally.
+#
+# Example with a router on port 20128:
+#   OPENAI_BASE_URL=http://localhost:20128/v1
+#   OPENAI_API_KEY=sk-router-anything    # most routers ignore this
+#   DEFAULT_MODEL=claude-sonnet-4-6      # whatever model id the router routes
+#
+# When OPENAI_BASE_URL is set, OpenAI-only options like reasoning summaries
+# are automatically disabled (the router/Claude won't accept them).
+OPENAI_BASE_URL=
+
+
 # ── Model selection ───────────────────────────
 
 # Override the default model for all agents (set automatically by onboarding).
-# OpenAI example:   DEFAULT_MODEL=gpt-5.2
-# Anthropic example: DEFAULT_MODEL=litellm/anthropic/claude-sonnet-4-6
-# Google example:   DEFAULT_MODEL=litellm/gemini/gemini-3-flash
+# OpenAI example:    DEFAULT_MODEL=gpt-5.2
+# Anthropic (API):   DEFAULT_MODEL=litellm/anthropic/claude-sonnet-4-6
+# Google example:    DEFAULT_MODEL=litellm/gemini/gemini-3-flash
+# Via local router:  DEFAULT_MODEL=claude-sonnet-4-6   (router maps the name)
 DEFAULT_MODEL=
 
 

--- a/.env.example
+++ b/.env.example
@@ -26,26 +26,29 @@ ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 
 
-# ── Direct Anthropic SDK + Claude Code OAuth (recommended) ──
+# ── Anthropic SDK via local router (recommended for subscription) ──
 #
-# When CLAUDE_CODE_OAUTH_TOKEN is set, every agent's model call goes
-# directly to api.anthropic.com via the official `anthropic` Python SDK
-# using OAuth Bearer auth and the oauth-2025-04-20 beta header. Calls
-# bill against your Claude Pro/Max/Claude Code subscription, no API
-# usage billing.
+# Point the Anthropic Python SDK at a local router (9router,
+# CLIProxyAPI, ccproxy) that authenticates against your Claude
+# Pro/Max/Claude Code subscription. The router does the OAuth dance
+# itself; we just send standard Anthropic Messages API requests to it
+# with the literal string "9router" as the api key.
 #
-# Generate a token with the Claude Code CLI:
-#     claude setup-token
+# This is the same pattern openswarm-ai uses (see
+# backend/apps/settings/credentials.py:get_anthropic_client).
 #
-# Format: sk-ant-oat01-...
-# In OAuth mode set DEFAULT_MODEL to a real Anthropic model id, e.g.
-#     claude-opus-4-5-20251101
-#     claude-sonnet-4-5-20250929
-#     claude-haiku-4-5-20251001
-CLAUDE_CODE_OAUTH_TOKEN=
+# Example with 9router:
+#   ANTHROPIC_BASE_URL=http://localhost:20128
+#   ANTHROPIC_API_KEY=9router
+#   DEFAULT_MODEL=cc/claude-opus-4-7
+#
+# Model id format depends on the router. 9router uses cc/<claude-id>
+# for Claude (subscription) and cx/<openai-id> for ChatGPT-routed
+# models.
+ANTHROPIC_BASE_URL=
 
 
-# ── Local LLM router (alternative path) ───────────────
+# ── Local OpenAI-compatible LLM router (alternative path) ──
 #
 # Route every model call through a local router (e.g. claude-code-router,
 # 9router, ccproxy) that authenticates with your Claude Pro/Max/Claude Code

--- a/.env.example
+++ b/.env.example
@@ -26,25 +26,32 @@ ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 
 
-# ── Anthropic SDK via local router (recommended for subscription) ──
+# ── Claude subscription via local `claude` CLI (recommended) ──
 #
-# Point the Anthropic Python SDK at a local router (9router,
-# CLIProxyAPI, ccproxy) that authenticates against your Claude
-# Pro/Max/Claude Code subscription. The router does the OAuth dance
-# itself; we just send standard Anthropic Messages API requests to it
-# with the literal string "9router" as the api key.
+# This is the openswarm-ai pattern. Requires:
+#   1. The `claude` CLI installed (npm install -g @anthropic-ai/claude-code).
+#   2. You've run `claude login` once — credentials are saved to ~/.claude.
+#   3. The `claude-agent-sdk` Python package is in requirements.txt.
 #
-# This is the same pattern openswarm-ai uses (see
-# backend/apps/settings/credentials.py:get_anthropic_client).
+# When DEFAULT_MODEL is a Claude id and no other backend env is set,
+# config.is_oauth_mode() auto-detects the SDK and routes every model
+# call through claude_agent_sdk, which spawns the local `claude`
+# binary. The CLI brings its own subscription auth — no API keys, no
+# OAuth tokens, no router needed.
 #
-# Example with 9router:
-#   ANTHROPIC_BASE_URL=http://localhost:20128
-#   ANTHROPIC_API_KEY=9router
-#   DEFAULT_MODEL=cc/claude-opus-4-7
+# Force the SDK path explicitly:
+CLAUDE_USE_AGENT_SDK=
 #
-# Model id format depends on the router. 9router uses cc/<claude-id>
-# for Claude (subscription) and cx/<openai-id> for ChatGPT-routed
-# models.
+# Re-enable Claude Code's built-in tools (Bash, WebSearch, Edit, etc.)
+# alongside agency-swarm tools. Off by default for behavior parity.
+CLAUDE_USE_BUILTIN_TOOLS=
+
+
+# ── Anthropic SDK pointed at a remote API or local proxy (alternative) ──
+#
+# Set ANTHROPIC_BASE_URL to point the Anthropic SDK at a remote
+# Claude-compatible endpoint or a local router (9router, CLIProxyAPI).
+# Leave blank for the recommended CLI path above.
 ANTHROPIC_BASE_URL=
 
 

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,26 @@ ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 
 
-# ── Local LLM router (use Claude Code subscription) ──
+# ── Direct Anthropic SDK + Claude Code OAuth (recommended) ──
+#
+# When CLAUDE_CODE_OAUTH_TOKEN is set, every agent's model call goes
+# directly to api.anthropic.com via the official `anthropic` Python SDK
+# using OAuth Bearer auth and the oauth-2025-04-20 beta header. Calls
+# bill against your Claude Pro/Max/Claude Code subscription, no API
+# usage billing.
+#
+# Generate a token with the Claude Code CLI:
+#     claude setup-token
+#
+# Format: sk-ant-oat01-...
+# In OAuth mode set DEFAULT_MODEL to a real Anthropic model id, e.g.
+#     claude-opus-4-5-20251101
+#     claude-sonnet-4-5-20250929
+#     claude-haiku-4-5-20251001
+CLAUDE_CODE_OAUTH_TOKEN=
+
+
+# ── Local LLM router (alternative path) ───────────────
 #
 # Route every model call through a local router (e.g. claude-code-router,
 # 9router, ccproxy) that authenticates with your Claude Pro/Max/Claude Code

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@
 OPENAI_API_KEY=
 
 # Anthropic Claude — set this if using Anthropic as your primary provider.
+#
+# Two kinds of tokens are accepted in this single variable:
+#   1. Standard API key from https://console.anthropic.com/settings/keys
+#      Format: sk-ant-api03-...
+#   2. Claude Pro / Max / Claude Code subscription OAuth token.
+#      Generate one with the Claude Code CLI:
+#          claude setup-token
+#      Format: sk-ant-oat01-...
+#      Using an OAuth token routes calls through your Claude subscription
+#      instead of pay-per-token API billing.
 ANTHROPIC_API_KEY=
 
 # Google Gemini — set this if using Google as your primary provider.
@@ -22,7 +32,7 @@ GOOGLE_API_KEY=
 
 # Override the default model for all agents (set automatically by onboarding).
 # OpenAI example:   DEFAULT_MODEL=gpt-5.2
-# Anthropic example: DEFAULT_MODEL=litellm/claude-sonnet-4-6
+# Anthropic example: DEFAULT_MODEL=litellm/anthropic/claude-sonnet-4-6
 # Google example:   DEFAULT_MODEL=litellm/gemini/gemini-3-flash
 DEFAULT_MODEL=
 

--- a/claude_oauth_model.py
+++ b/claude_oauth_model.py
@@ -1,47 +1,65 @@
-"""OpenAI Agents SDK Model adapter that talks to Anthropic Messages API
-through a local OpenAI-compatible router (9router/CLIProxyAPI/etc.).
+"""OpenAI Agents SDK Model adapter that runs Claude via the local
+`claude` CLI using `claude_agent_sdk`.
 
-Why this exists:
-- LiteLLM via agency-swarm rejects router model namespaces like
-  'cc/claude-opus-4-7' with 'Unknown prefix: cc'.
-- The router (9router) authenticates against your Claude Pro / Max /
-  Claude Code subscription itself; it expects the literal API key
-  string '9router' on the Anthropic Messages endpoint and routes by
-  the model id (cc/..., cx/..., gc/...).
-- We hand agency-swarm a Model instance bound to that router so the
-  rest of the framework treats it like any other Anthropic backend.
+Auth strategy (mirrors openswarm-ai):
+    The local `claude` CLI carries the user's Claude Pro/Max/Claude
+    Code subscription credentials (saved by `claude login`). The
+    `claude_agent_sdk` Python package spawns that CLI and inherits its
+    auth. We don't touch tokens, OAuth, or API keys — the SDK does it
+    via the subprocess.
 
-Auth:
-- The Anthropic Python SDK is constructed with `api_key="9router"`
-  and `base_url=<router URL>`. No OAuth token, no Bearer, no special
-  beta header — the router does subscription auth on our behalf.
-  This is the same pattern used by openswarm-ai's backend.
+Usage flow:
+    Each call to ClaudeAgentSDKModel.get_response():
+      1. Builds an in-process SDK MCP server exposing agency-swarm's
+         tools as MCP tools (so Claude can actually invoke them).
+      2. Constructs ClaudeAgentOptions with that MCP server, the
+         agent's system instructions, and Claude Code's built-in
+         tools disabled (only our agency-swarm tools are exposed).
+      3. Calls claude_agent_sdk.query() with the conversation
+         transcript as a single prompt.
+      4. The SDK runs Claude → tool → Claude … until Claude returns
+         a final assistant message. All tool calls happen inside this
+         one query() invocation.
+      5. We translate the final messages back into OpenAI Responses-
+         shaped output items so agency-swarm consumes them unchanged.
 
-Translation:
-- OpenAI Agents SDK input items (Responses-API-shaped) → Anthropic
-  Messages API blocks (text / tool_use / tool_result).
-- OpenAI tool / handoff schemas → Anthropic tool definitions.
-- Anthropic content blocks → OpenAI Responses-style output items so
-  agency-swarm consumes the response unchanged.
-
-Streaming:
-- stream_response drives anthropic.messages.stream() and emits
-  per-token text-delta events plus a final completed event.
+Limitations (acknowledged):
+  - Past tool calls in the input are flattened into a text transcript;
+    Claude can't re-issue them as if it had generated them itself.
+  - Claude Code's built-in tools (Bash, WebSearch, Edit) are disabled
+    by default to keep behavior parity with agency-swarm. Set
+    CLAUDE_USE_BUILTIN_TOOLS=1 to re-enable them.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
 from typing import Any, AsyncIterator
 
 try:
-    import anthropic  # type: ignore
+    from claude_agent_sdk import (  # type: ignore
+        query as _sdk_query,
+        ClaudeAgentOptions,
+        AssistantMessage,
+        ResultMessage,
+        SystemMessage,
+        UserMessage,
+        tool as _sdk_tool,
+        create_sdk_mcp_server,
+    )
+    from claude_agent_sdk.types import (  # type: ignore
+        TextBlock,
+        ToolUseBlock,
+    )
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "ClaudeRouterModel requires the `anthropic` package. "
-        "Install with: pip install anthropic"
+        "ClaudeAgentSDKModel requires the `claude-agent-sdk` package. "
+        "Install with: pip install claude-agent-sdk\n"
+        "It also requires the `claude` CLI to be installed and logged in "
+        "(`claude login`)."
     ) from exc
 
 from agents import Model, ModelResponse, ModelSettings, ModelTracing
@@ -50,41 +68,12 @@ from agents.tool import Tool
 from agents.usage import Usage
 
 
-_DEFAULT_ROUTER_URL = "http://localhost:20128"
-_DEFAULT_MAX_TOKENS = 8192
+class ClaudeAgentSDKModel(Model):
+    """Model adapter backed by `claude_agent_sdk` + local `claude` CLI."""
 
-
-class ClaudeRouterModel(Model):
-    """Model adapter that calls Anthropic Messages API through a local router."""
-
-    def __init__(
-        self,
-        model: str,
-        base_url: str | None = None,
-        api_key: str | None = None,
-        max_tokens: int = _DEFAULT_MAX_TOKENS,
-    ) -> None:
-        # Convention used by 9router/CLIProxyAPI: literal string "9router"
-        # in the api_key slot, the router itself authenticates upstream.
-        # ANTHROPIC_BASE_URL takes precedence so the user can repoint to
-        # any other Anthropic-Messages-compatible router.
-        resolved_base = (
-            base_url
-            or os.getenv("ANTHROPIC_BASE_URL")
-            or _strip_v1(os.getenv("OPENAI_BASE_URL", ""))
-            or _DEFAULT_ROUTER_URL
-        )
-        resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY") or "9router"
-
-        self._client = anthropic.AsyncAnthropic(
-            api_key=resolved_key,
-            base_url=resolved_base,
-        )
+    def __init__(self, model: str) -> None:
         self._model = model
-        self._max_tokens = max_tokens
-
-    # Backwards-compat alias.
-    ClaudeOAuthModel = property(lambda self: self)
+        self._use_builtin_tools = os.getenv("CLAUDE_USE_BUILTIN_TOOLS", "").lower() in ("1", "true", "yes")
 
     async def get_response(
         self,
@@ -100,27 +89,32 @@ class ClaudeRouterModel(Model):
         conversation_id: str | None = None,
         prompt: Any | None = None,
     ) -> ModelResponse:
-        messages = _input_to_anthropic_messages(input)
-        system = _build_system_prompt(system_instructions, output_schema)
-        anthropic_tools = _tools_to_anthropic(tools, handoffs)
+        text_chunks: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        usage = Usage()
 
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            "max_tokens": getattr(model_settings, "max_tokens", None) or self._max_tokens,
-            "system": system,
-            "messages": messages,
-        }
-        if anthropic_tools:
-            kwargs["tools"] = anthropic_tools
-        temperature = getattr(model_settings, "temperature", None)
-        if temperature is not None:
-            kwargs["temperature"] = temperature
-        top_p = getattr(model_settings, "top_p", None)
-        if top_p is not None:
-            kwargs["top_p"] = top_p
+        async for msg in self._run_query(
+            system_instructions, input, tools, handoffs, output_schema
+        ):
+            if isinstance(msg, AssistantMessage):
+                for block in getattr(msg, "content", []) or []:
+                    if isinstance(block, TextBlock):
+                        t = getattr(block, "text", "") or ""
+                        if t:
+                            text_chunks.append(t)
+                    elif isinstance(block, ToolUseBlock):
+                        # Captured for visibility; the SDK already
+                        # executed the tool via our MCP server before
+                        # this final assembly.
+                        tool_calls.append({
+                            "id": getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:24]}",
+                            "name": _strip_mcp_prefix(getattr(block, "name", "") or ""),
+                            "input": getattr(block, "input", {}) or {},
+                        })
+            elif isinstance(msg, ResultMessage):
+                _accumulate_usage(usage, msg)
 
-        response = await self._client.messages.create(**kwargs)
-        return _anthropic_response_to_model_response(response)
+        return _build_model_response(text_chunks, tool_calls, usage)
 
     def stream_response(
         self,
@@ -158,29 +152,6 @@ class ClaudeRouterModel(Model):
         conversation_id: str | None = None,
         prompt: Any | None = None,
     ) -> AsyncIterator[Any]:
-        messages = _input_to_anthropic_messages(input)
-        system = _build_system_prompt(system_instructions, output_schema)
-        anthropic_tools = _tools_to_anthropic(tools, handoffs)
-
-        kwargs: dict[str, Any] = {
-            "model": self._model,
-            "max_tokens": getattr(model_settings, "max_tokens", None) or self._max_tokens,
-            "system": system,
-            "messages": messages,
-        }
-        if anthropic_tools:
-            kwargs["tools"] = anthropic_tools
-        temperature = getattr(model_settings, "temperature", None)
-        if temperature is not None:
-            kwargs["temperature"] = temperature
-
-        seq = 0
-
-        def _next() -> int:
-            nonlocal seq
-            seq += 1
-            return seq
-
         try:
             from openai.types.responses import (  # noqa: PLC0415
                 ResponseTextDeltaEvent,
@@ -191,26 +162,46 @@ class ClaudeRouterModel(Model):
         except ImportError:
             have_event_types = False
 
-        async with self._client.messages.stream(**kwargs) as stream:
-            async for event in stream:
-                etype = getattr(event, "type", None)
-                if etype == "content_block_delta":
-                    delta = getattr(event, "delta", None)
-                    if getattr(delta, "type", None) == "text_delta" and have_event_types:
-                        text = getattr(delta, "text", "") or ""
-                        if not text:
-                            continue
-                        yield ResponseTextDeltaEvent.model_construct(
-                            type="response.output_text.delta",
-                            delta=text,
-                            item_id=f"item_{getattr(event, 'index', 0) or 0}",
-                            output_index=int(getattr(event, "index", 0) or 0),
-                            content_index=0,
-                            sequence_number=_next(),
-                        )
-            final = await stream.get_final_message()
+        seq = 0
 
-        result = _anthropic_response_to_model_response(final)
+        def _next() -> int:
+            nonlocal seq
+            seq += 1
+            return seq
+
+        text_chunks: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        usage = Usage()
+
+        async for msg in self._run_query(
+            system_instructions, input, tools, handoffs, output_schema
+        ):
+            if isinstance(msg, AssistantMessage):
+                for block in getattr(msg, "content", []) or []:
+                    if isinstance(block, TextBlock):
+                        t = getattr(block, "text", "") or ""
+                        if not t:
+                            continue
+                        text_chunks.append(t)
+                        if have_event_types:
+                            yield ResponseTextDeltaEvent.model_construct(
+                                type="response.output_text.delta",
+                                delta=t,
+                                item_id="item_0",
+                                output_index=0,
+                                content_index=0,
+                                sequence_number=_next(),
+                            )
+                    elif isinstance(block, ToolUseBlock):
+                        tool_calls.append({
+                            "id": getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:24]}",
+                            "name": _strip_mcp_prefix(getattr(block, "name", "") or ""),
+                            "input": getattr(block, "input", {}) or {},
+                        })
+            elif isinstance(msg, ResultMessage):
+                _accumulate_usage(usage, msg)
+
+        result = _build_model_response(text_chunks, tool_calls, usage)
         if have_event_types:
             yield ResponseCompletedEvent.model_construct(
                 type="response.completed",
@@ -229,24 +220,113 @@ class ClaudeRouterModel(Model):
                 ),
             )
 
+    # ── internals ────────────────────────────────────────────────────────
 
-# Backwards-compat: keep the old import name working.
-ClaudeOAuthModel = ClaudeRouterModel
+    async def _run_query(
+        self,
+        system_instructions: str | None,
+        input: str | list[Any],
+        tools: list[Tool],
+        handoffs: list[Handoff],
+        output_schema: Any | None,
+    ):
+        prompt = _input_to_prompt(input)
+        sdk_tools, tool_name_index = _wrap_tools_for_sdk(tools, handoffs)
+
+        options_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "system_prompt": _build_system_prompt(system_instructions, output_schema),
+            "permission_mode": "bypassPermissions",
+        }
+
+        mcp_servers: dict[str, Any] = {}
+        allowed_tools: list[str] = []
+        if sdk_tools:
+            mcp_servers["agency"] = create_sdk_mcp_server(name="agency", tools=sdk_tools)
+            allowed_tools = [f"mcp__agency__{name}" for name in tool_name_index]
+
+        if not self._use_builtin_tools:
+            # Restrict the run to only our wrapped tools — keeps behavior
+            # consistent with agency-swarm's tool surface. To re-enable
+            # Claude Code's built-ins (Bash, WebSearch, etc.) set
+            # CLAUDE_USE_BUILTIN_TOOLS=1.
+            options_kwargs["allowed_tools"] = allowed_tools
+            options_kwargs["disallowed_tools"] = ["Bash", "Edit", "Write", "Read", "WebSearch", "Grep", "Glob"]
+
+        if mcp_servers:
+            options_kwargs["mcp_servers"] = mcp_servers
+
+        options = ClaudeAgentOptions(**options_kwargs)
+
+        async for msg in _sdk_query(prompt=prompt, options=options):
+            yield msg
 
 
-# ── translation helpers ──────────────────────────────────────────────────
+# ── helpers ──────────────────────────────────────────────────────────────
 
-def _strip_v1(url: str) -> str:
-    if url.endswith("/v1"):
-        return url[:-3]
-    if url.endswith("/v1/"):
-        return url[:-4]
-    return url
+_MCP_NAME_RE = re.compile(r"[^A-Za-z0-9_]")
 
 
-def _build_system_prompt(
-    system_instructions: str | None, output_schema: Any | None
-) -> str:
+def _sanitize_tool_name(name: str) -> str:
+    """Make a name MCP-safe: only alnum + underscore."""
+    cleaned = _MCP_NAME_RE.sub("_", name or "tool")
+    return cleaned[:60] or "tool"
+
+
+def _strip_mcp_prefix(name: str) -> str:
+    """'mcp__agency__SomeTool' → 'SomeTool'."""
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        if len(parts) == 3:
+            return parts[2]
+    return name
+
+
+def _wrap_tools_for_sdk(
+    tools: list[Tool], handoffs: list[Handoff]
+) -> tuple[list[Any], list[str]]:
+    """Wrap each agency-swarm tool/handoff as a claude_agent_sdk @tool."""
+    sdk_tools: list[Any] = []
+    names: list[str] = []
+    for t in list(tools) + list(handoffs):
+        name = _sanitize_tool_name(getattr(t, "name", "") or f"tool_{len(sdk_tools)}")
+        description = getattr(t, "description", "") or name
+        schema = (
+            getattr(t, "params_json_schema", None)
+            or getattr(t, "input_schema", None)
+            or {"type": "object", "properties": {}}
+        )
+
+        # Capture in default args to pin per-iteration values.
+        async def _wrapper(args: dict, _t=t, _name=name) -> dict:
+            try:
+                args_json = json.dumps(args or {})
+                invoke = getattr(_t, "on_invoke_tool", None)
+                if invoke is None:
+                    return _mcp_text_result(f"Tool {_name} has no on_invoke_tool method")
+                # ctx=None — agency-swarm tools that need context will
+                # raise; the error text is surfaced to Claude as the
+                # tool result so the run continues.
+                result = await invoke(None, args_json)
+                if isinstance(result, (dict, list)):
+                    text = json.dumps(result)
+                else:
+                    text = str(result)
+                return _mcp_text_result(text)
+            except Exception as e:
+                return _mcp_text_result(f"Tool error in {_name}: {e}")
+
+        # claude_agent_sdk's @tool decorator returns a wrapped tool spec.
+        sdk_tools.append(_sdk_tool(name, description, schema)(_wrapper))
+        names.append(name)
+    return sdk_tools, names
+
+
+def _mcp_text_result(text: str) -> dict:
+    return {"content": [{"type": "text", "text": text[:50_000]}]}
+
+
+def _build_system_prompt(system_instructions: str | None, output_schema: Any | None) -> str:
     parts: list[str] = []
     if system_instructions:
         parts.append(system_instructions)
@@ -262,83 +342,62 @@ def _build_system_prompt(
     return "\n\n".join(parts) if parts else "You are a helpful assistant."
 
 
-def _input_to_anthropic_messages(
-    input_items: str | list[Any],
-) -> list[dict[str, Any]]:
+def _input_to_prompt(input_items: str | list[Any]) -> str:
+    """Flatten the OpenAI Responses-style input into a single text prompt.
+
+    Past tool calls/results are included as text so Claude has context,
+    but we don't try to replay them as native tool_use blocks (Claude
+    can't reissue something it didn't generate this run).
+    """
     if isinstance(input_items, str):
-        return [{"role": "user", "content": [{"type": "text", "text": input_items}]}]
+        return input_items
 
-    messages: list[dict[str, Any]] = []
-    pending_assistant_blocks: list[dict[str, Any]] = []
-    pending_tool_results: list[dict[str, Any]] = []
-
-    def _flush_assistant() -> None:
-        if pending_assistant_blocks:
-            messages.append({"role": "assistant", "content": list(pending_assistant_blocks)})
-            pending_assistant_blocks.clear()
-
-    def _flush_tool_results() -> None:
-        if pending_tool_results:
-            messages.append({"role": "user", "content": list(pending_tool_results)})
-            pending_tool_results.clear()
-
+    lines: list[str] = []
     for item in input_items:
         d = _as_dict(item)
         item_type = d.get("type")
 
         if item_type == "function_call":
-            _flush_tool_results()
             args = d.get("arguments")
             if isinstance(args, str):
+                args_repr = args
+            else:
                 try:
-                    args = json.loads(args) if args else {}
+                    args_repr = json.dumps(args)
                 except Exception:
-                    args = {}
-            pending_assistant_blocks.append({
-                "type": "tool_use",
-                "id": d.get("call_id") or d.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
-                "name": d.get("name") or "",
-                "input": args or {},
-            })
+                    args_repr = str(args)
+            lines.append(f"[assistant tool call] {d.get('name', '')}({args_repr})")
             continue
-
         if item_type == "function_call_output":
-            _flush_assistant()
-            content = d.get("output")
-            if not isinstance(content, str):
+            out = d.get("output")
+            if not isinstance(out, str):
                 try:
-                    content = json.dumps(content)
+                    out = json.dumps(out)
                 except Exception:
-                    content = str(content)
-            pending_tool_results.append({
-                "type": "tool_result",
-                "tool_use_id": d.get("call_id") or d.get("id") or "",
-                "content": content,
-            })
+                    out = str(out)
+            lines.append(f"[tool result] {out}")
             continue
-
         if item_type == "reasoning":
             continue
 
-        role = d.get("role") or ("assistant" if item_type == "message" and d.get("status") else "user")
         text = _extract_text(d)
         if text is None:
             continue
-
+        role = d.get("role") or "user"
         if role == "assistant":
-            _flush_tool_results()
-            pending_assistant_blocks.append({"type": "text", "text": text})
+            lines.append(f"Assistant: {text}")
+        elif role == "system":
+            lines.append(f"System: {text}")
         else:
-            _flush_assistant()
-            _flush_tool_results()
-            messages.append({"role": "user", "content": [{"type": "text", "text": text}]})
+            lines.append(f"User: {text}")
 
-    _flush_assistant()
-    _flush_tool_results()
+    if not lines:
+        return ""
 
-    if not messages:
-        messages = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
-    return messages
+    # The actual NEW user message is whatever the agent just said —
+    # that's the last 'User: ...' or the last item overall. Keep it
+    # all together as a transcript ending with the latest turn.
+    return "\n".join(lines)
 
 
 def _as_dict(item: Any) -> dict[str, Any]:
@@ -375,75 +434,48 @@ def _extract_text(d: dict[str, Any]) -> str | None:
     return None
 
 
-def _tools_to_anthropic(tools: list[Tool], handoffs: list[Handoff]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = []
-    for tool in list(tools) + list(handoffs):
-        name = getattr(tool, "name", None)
-        description = getattr(tool, "description", "") or ""
-        schema = (
-            getattr(tool, "params_json_schema", None)
-            or getattr(tool, "input_schema", None)
-            or {"type": "object", "properties": {}}
-        )
-        if name:
-            out.append({
-                "name": name,
-                "description": description,
-                "input_schema": schema,
-            })
-    return out
+def _accumulate_usage(usage: Usage, msg: Any) -> None:
+    raw = getattr(msg, "usage", None) or {}
+    if isinstance(raw, dict):
+        try:
+            usage.input_tokens += int(raw.get("input_tokens", 0) or 0)
+            usage.output_tokens += int(raw.get("output_tokens", 0) or 0)
+            usage.total_tokens = usage.input_tokens + usage.output_tokens
+            usage.requests += 1
+        except Exception:
+            pass
 
 
-def _anthropic_response_to_model_response(response: Any) -> ModelResponse:
+def _build_model_response(
+    text_chunks: list[str],
+    tool_calls: list[dict[str, Any]],
+    usage: Usage,
+) -> ModelResponse:
     output_items: list[Any] = []
-    response_id = getattr(response, "id", None) or f"resp_{uuid.uuid4().hex}"
-    content_blocks = getattr(response, "content", []) or []
-
-    text_chunks: list[str] = []
-    tool_calls: list[dict[str, Any]] = []
-    for block in content_blocks:
-        block_type = getattr(block, "type", None)
-        if block_type == "text":
-            text_chunks.append(getattr(block, "text", "") or "")
-        elif block_type == "tool_use":
-            tool_calls.append({
-                "id": getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:24]}",
-                "name": getattr(block, "name", "") or "",
-                "input": getattr(block, "input", {}) or {},
-            })
-
     if text_chunks:
         output_items.append({
             "type": "message",
             "id": f"msg_{uuid.uuid4().hex}",
             "role": "assistant",
             "status": "completed",
-            "content": [{"type": "output_text", "text": "".join(text_chunks), "annotations": []}],
+            "content": [{
+                "type": "output_text",
+                "text": "".join(text_chunks),
+                "annotations": [],
+            }],
         })
-
-    for call in tool_calls:
-        output_items.append({
-            "type": "function_call",
-            "id": call["id"],
-            "call_id": call["id"],
-            "name": call["name"],
-            "arguments": json.dumps(call["input"]),
-            "status": "completed",
-        })
-
-    usage = Usage()
-    raw_usage = getattr(response, "usage", None)
-    if raw_usage is not None:
-        try:
-            usage.input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
-            usage.output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
-            usage.total_tokens = usage.input_tokens + usage.output_tokens
-            usage.requests = 1
-        except Exception:
-            pass
+    # Note: tool_calls are NOT re-emitted as function_call output items.
+    # The SDK already executed the tools internally via our MCP server,
+    # so agency-swarm doesn't need to dispatch them again. Re-emitting
+    # would cause the runner to call the tools a second time.
 
     return ModelResponse(
         output=output_items,
         usage=usage,
-        response_id=response_id,
+        response_id=f"resp_{uuid.uuid4().hex}",
     )
+
+
+# Backwards-compat aliases so existing imports keep working.
+ClaudeOAuthModel = ClaudeAgentSDKModel
+ClaudeRouterModel = ClaudeAgentSDKModel

--- a/claude_oauth_model.py
+++ b/claude_oauth_model.py
@@ -71,9 +71,11 @@ from agents.usage import Usage
 class ClaudeAgentSDKModel(Model):
     """Model adapter backed by `claude_agent_sdk` + local `claude` CLI."""
 
-    def __init__(self, model: str) -> None:
+    def __init__(self, model: str, use_builtin_tools: bool | None = None) -> None:
         self._model = model
-        self._use_builtin_tools = os.getenv("CLAUDE_USE_BUILTIN_TOOLS", "").lower() in ("1", "true", "yes")
+        if use_builtin_tools is None:
+            use_builtin_tools = os.getenv("CLAUDE_USE_BUILTIN_TOOLS", "").lower() in ("1", "true", "yes")
+        self._use_builtin_tools = bool(use_builtin_tools)
 
     async def get_response(
         self,

--- a/claude_oauth_model.py
+++ b/claude_oauth_model.py
@@ -1,37 +1,32 @@
-"""Custom OpenAI Agents SDK Model adapter that talks to the Anthropic
-Messages API directly using the official `anthropic` Python SDK, with a
-Claude Pro/Max/Claude Code subscription OAuth token (no API billing).
+"""OpenAI Agents SDK Model adapter that talks to Anthropic Messages API
+through a local OpenAI-compatible router (9router/CLIProxyAPI/etc.).
 
 Why this exists:
-- LiteLLM's anthropic provider sends OAuth tokens via x-api-key (wrong
-  header for OAuth) and skips the required `anthropic-beta` header, so
-  oat tokens silently fail through LiteLLM/agency-swarm's normal path.
-- We need to keep agency-swarm's agents/communication-flows/TUI intact
-  while routing every model call through Claude with subscription
-  billing. A custom Model adapter is the minimum-invasive way to do
-  that.
+- LiteLLM via agency-swarm rejects router model namespaces like
+  'cc/claude-opus-4-7' with 'Unknown prefix: cc'.
+- The router (9router) authenticates against your Claude Pro / Max /
+  Claude Code subscription itself; it expects the literal API key
+  string '9router' on the Anthropic Messages endpoint and routes by
+  the model id (cc/..., cx/..., gc/...).
+- We hand agency-swarm a Model instance bound to that router so the
+  rest of the framework treats it like any other Anthropic backend.
 
 Auth:
-- `auth_token=...`  → SDK sends `Authorization: Bearer <token>`.
-- `default_headers={"anthropic-beta": "oauth-2025-04-20"}`.
-- A `You are Claude Code, Anthropic's official CLI for Claude.` prefix
-  is prepended to the system prompt — Anthropic's subscription billing
-  path requires the request to identify as Claude Code.
+- The Anthropic Python SDK is constructed with `api_key="9router"`
+  and `base_url=<router URL>`. No OAuth token, no Bearer, no special
+  beta header — the router does subscription auth on our behalf.
+  This is the same pattern used by openswarm-ai's backend.
 
 Translation:
 - OpenAI Agents SDK input items (Responses-API-shaped) → Anthropic
   Messages API blocks (text / tool_use / tool_result).
-- OpenAI tool definitions (function with JSON-Schema parameters) →
-  Anthropic tool definitions (name, description, input_schema).
-- Anthropic content blocks (text / tool_use) → OpenAI Responses-style
-  output items so the rest of agency-swarm consumes them unchanged.
+- OpenAI tool / handoff schemas → Anthropic tool definitions.
+- Anthropic content blocks → OpenAI Responses-style output items so
+  agency-swarm consumes the response unchanged.
 
 Streaming:
-- `stream_response` is implemented in best-effort form: it calls
-  `get_response` and emits the result as a single batch of synthetic
-  Responses-API stream events. Real token-by-token streaming is a
-  future optimisation; the TUI still renders the final assistant
-  message correctly.
+- stream_response drives anthropic.messages.stream() and emits
+  per-token text-delta events plus a final completed event.
 """
 
 from __future__ import annotations
@@ -45,7 +40,7 @@ try:
     import anthropic  # type: ignore
 except ImportError as exc:  # pragma: no cover
     raise ImportError(
-        "ClaudeOAuthModel requires the `anthropic` package. "
+        "ClaudeRouterModel requires the `anthropic` package. "
         "Install with: pip install anthropic"
     ) from exc
 
@@ -55,42 +50,41 @@ from agents.tool import Tool
 from agents.usage import Usage
 
 
-_OAUTH_BETA_HEADER = "oauth-2025-04-20"
-_CLAUDE_CODE_PREAMBLE = "You are Claude Code, Anthropic's official CLI for Claude."
+_DEFAULT_ROUTER_URL = "http://localhost:20128"
 _DEFAULT_MAX_TOKENS = 8192
 
 
-class ClaudeOAuthModel(Model):
-    """Model adapter that calls Anthropic Messages API with an OAuth token."""
+class ClaudeRouterModel(Model):
+    """Model adapter that calls Anthropic Messages API through a local router."""
 
     def __init__(
         self,
         model: str,
-        oauth_token: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
         max_tokens: int = _DEFAULT_MAX_TOKENS,
     ) -> None:
-        token = (
-            oauth_token
-            or os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
-            or os.getenv("ANTHROPIC_API_KEY")
+        # Convention used by 9router/CLIProxyAPI: literal string "9router"
+        # in the api_key slot, the router itself authenticates upstream.
+        # ANTHROPIC_BASE_URL takes precedence so the user can repoint to
+        # any other Anthropic-Messages-compatible router.
+        resolved_base = (
+            base_url
+            or os.getenv("ANTHROPIC_BASE_URL")
+            or _strip_v1(os.getenv("OPENAI_BASE_URL", ""))
+            or _DEFAULT_ROUTER_URL
         )
-        if not token:
-            raise RuntimeError(
-                "ClaudeOAuthModel needs CLAUDE_CODE_OAUTH_TOKEN (preferred) "
-                "or ANTHROPIC_API_KEY in the environment."
-            )
+        resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY") or "9router"
 
-        # auth_token=  → Authorization: Bearer <token>
-        # api_key=None → suppress x-api-key header.
         self._client = anthropic.AsyncAnthropic(
-            api_key=None,
-            auth_token=token,
-            default_headers={"anthropic-beta": _OAUTH_BETA_HEADER},
+            api_key=resolved_key,
+            base_url=resolved_base,
         )
         self._model = model
         self._max_tokens = max_tokens
 
-    # ── core API ──────────────────────────────────────────────────────────
+    # Backwards-compat alias.
+    ClaudeOAuthModel = property(lambda self: self)
 
     async def get_response(
         self,
@@ -142,17 +136,9 @@ class ClaudeOAuthModel(Model):
         conversation_id: str | None = None,
         prompt: Any | None = None,
     ) -> AsyncIterator[Any]:
-        # The SDK calls `async for event in stream_response(...)` so this
-        # must return an async iterator (NOT a coroutine that resolves to
-        # one). Define an inner async generator and return it un-awaited.
         return self._stream_iter(
-            system_instructions,
-            input,
-            model_settings,
-            tools,
-            output_schema,
-            handoffs,
-            tracing,
+            system_instructions, input, model_settings, tools, output_schema,
+            handoffs, tracing,
             previous_response_id=previous_response_id,
             conversation_id=conversation_id,
             prompt=prompt,
@@ -172,9 +158,6 @@ class ClaudeOAuthModel(Model):
         conversation_id: str | None = None,
         prompt: Any | None = None,
     ) -> AsyncIterator[Any]:
-        # Best-effort streaming: drive Anthropic's native stream and emit
-        # text-delta + completed events so the TUI renders text live and
-        # the SDK can extract the final ModelResponse on completion.
         messages = _input_to_anthropic_messages(input)
         system = _build_system_prompt(system_instructions, output_schema)
         anthropic_tools = _tools_to_anthropic(tools, handoffs)
@@ -198,8 +181,6 @@ class ClaudeOAuthModel(Model):
             seq += 1
             return seq
 
-        # Lazy-import event types: model_construct() bypasses Pydantic
-        # validation so we don't have to fully populate every field.
         try:
             from openai.types.responses import (  # noqa: PLC0415
                 ResponseTextDeltaEvent,
@@ -215,27 +196,21 @@ class ClaudeOAuthModel(Model):
                 etype = getattr(event, "type", None)
                 if etype == "content_block_delta":
                     delta = getattr(event, "delta", None)
-                    delta_type = getattr(delta, "type", None)
-                    if delta_type == "text_delta" and have_event_types:
+                    if getattr(delta, "type", None) == "text_delta" and have_event_types:
                         text = getattr(delta, "text", "") or ""
                         if not text:
                             continue
                         yield ResponseTextDeltaEvent.model_construct(
                             type="response.output_text.delta",
                             delta=text,
-                            item_id=getattr(event, "index", 0) and f"item_{event.index}" or "item_0",
+                            item_id=f"item_{getattr(event, 'index', 0) or 0}",
                             output_index=int(getattr(event, "index", 0) or 0),
                             content_index=0,
                             sequence_number=_next(),
                         )
-                # We ignore content_block_start/stop, message_start/stop —
-                # the final ResponseCompletedEvent below carries everything
-                # the SDK needs to reconstruct the result.
-
             final = await stream.get_final_message()
 
         result = _anthropic_response_to_model_response(final)
-
         if have_event_types:
             yield ResponseCompletedEvent.model_construct(
                 type="response.completed",
@@ -255,12 +230,24 @@ class ClaudeOAuthModel(Model):
             )
 
 
+# Backwards-compat: keep the old import name working.
+ClaudeOAuthModel = ClaudeRouterModel
+
+
 # ── translation helpers ──────────────────────────────────────────────────
+
+def _strip_v1(url: str) -> str:
+    if url.endswith("/v1"):
+        return url[:-3]
+    if url.endswith("/v1/"):
+        return url[:-4]
+    return url
+
 
 def _build_system_prompt(
     system_instructions: str | None, output_schema: Any | None
-) -> list[dict[str, Any]] | str:
-    parts: list[str] = [_CLAUDE_CODE_PREAMBLE]
+) -> str:
+    parts: list[str] = []
     if system_instructions:
         parts.append(system_instructions)
     if output_schema is not None:
@@ -272,13 +259,12 @@ def _build_system_prompt(
             )
         except Exception:
             pass
-    return "\n\n".join(parts)
+    return "\n\n".join(parts) if parts else "You are a helpful assistant."
 
 
 def _input_to_anthropic_messages(
     input_items: str | list[Any],
 ) -> list[dict[str, Any]]:
-    """Convert OpenAI Agents SDK input items to Anthropic messages."""
     if isinstance(input_items, str):
         return [{"role": "user", "content": [{"type": "text", "text": input_items}]}]
 
@@ -332,11 +318,8 @@ def _input_to_anthropic_messages(
             continue
 
         if item_type == "reasoning":
-            # Anthropic's thinking blocks aren't reusable across requests
-            # without server-side state — skip.
             continue
 
-        # Treat everything else as a message.
         role = d.get("role") or ("assistant" if item_type == "message" and d.get("status") else "user")
         text = _extract_text(d)
         if text is None:
@@ -412,9 +395,7 @@ def _tools_to_anthropic(tools: list[Tool], handoffs: list[Handoff]) -> list[dict
 
 
 def _anthropic_response_to_model_response(response: Any) -> ModelResponse:
-    """Convert an Anthropic Messages response into an OpenAI ModelResponse."""
     output_items: list[Any] = []
-
     response_id = getattr(response, "id", None) or f"resp_{uuid.uuid4().hex}"
     content_blocks = getattr(response, "content", []) or []
 
@@ -423,8 +404,7 @@ def _anthropic_response_to_model_response(response: Any) -> ModelResponse:
     for block in content_blocks:
         block_type = getattr(block, "type", None)
         if block_type == "text":
-            text = getattr(block, "text", "") or ""
-            text_chunks.append(text)
+            text_chunks.append(getattr(block, "text", "") or "")
         elif block_type == "tool_use":
             tool_calls.append({
                 "id": getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:24]}",
@@ -467,13 +447,3 @@ def _anthropic_response_to_model_response(response: Any) -> ModelResponse:
         usage=usage,
         response_id=response_id,
     )
-
-
-def _model_response_to_stream_events(response: ModelResponse) -> list[Any]:
-    """Best-effort conversion of a final ModelResponse into stream events.
-
-    Returns an empty list — agency-swarm's streaming consumers tolerate this
-    and fall back to the final ModelResponse pulled separately. If your TUI
-    needs token-by-token rendering, this is the function to expand.
-    """
-    return []

--- a/claude_oauth_model.py
+++ b/claude_oauth_model.py
@@ -128,7 +128,7 @@ class ClaudeOAuthModel(Model):
         response = await self._client.messages.create(**kwargs)
         return _anthropic_response_to_model_response(response)
 
-    async def stream_response(
+    def stream_response(
         self,
         system_instructions: str | None,
         input: str | list[Any],
@@ -142,11 +142,10 @@ class ClaudeOAuthModel(Model):
         conversation_id: str | None = None,
         prompt: Any | None = None,
     ) -> AsyncIterator[Any]:
-        # Best-effort: drive Anthropic's streaming, but fall back to a
-        # single-shot response wrapped in synthetic events. Real per-token
-        # streaming requires emitting the right TResponseStreamEvent variants
-        # which are intricate; this keeps the TUI functional.
-        result = await self.get_response(
+        # The SDK calls `async for event in stream_response(...)` so this
+        # must return an async iterator (NOT a coroutine that resolves to
+        # one). Define an inner async generator and return it un-awaited.
+        return self._stream_iter(
             system_instructions,
             input,
             model_settings,
@@ -159,11 +158,101 @@ class ClaudeOAuthModel(Model):
             prompt=prompt,
         )
 
-        async def _gen() -> AsyncIterator[Any]:
-            for event in _model_response_to_stream_events(result):
-                yield event
+    async def _stream_iter(
+        self,
+        system_instructions: str | None,
+        input: str | list[Any],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: Any | None,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        prompt: Any | None = None,
+    ) -> AsyncIterator[Any]:
+        # Best-effort streaming: drive Anthropic's native stream and emit
+        # text-delta + completed events so the TUI renders text live and
+        # the SDK can extract the final ModelResponse on completion.
+        messages = _input_to_anthropic_messages(input)
+        system = _build_system_prompt(system_instructions, output_schema)
+        anthropic_tools = _tools_to_anthropic(tools, handoffs)
 
-        return _gen()
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": getattr(model_settings, "max_tokens", None) or self._max_tokens,
+            "system": system,
+            "messages": messages,
+        }
+        if anthropic_tools:
+            kwargs["tools"] = anthropic_tools
+        temperature = getattr(model_settings, "temperature", None)
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+
+        seq = 0
+
+        def _next() -> int:
+            nonlocal seq
+            seq += 1
+            return seq
+
+        # Lazy-import event types: model_construct() bypasses Pydantic
+        # validation so we don't have to fully populate every field.
+        try:
+            from openai.types.responses import (  # noqa: PLC0415
+                ResponseTextDeltaEvent,
+                ResponseCompletedEvent,
+                Response,
+            )
+            have_event_types = True
+        except ImportError:
+            have_event_types = False
+
+        async with self._client.messages.stream(**kwargs) as stream:
+            async for event in stream:
+                etype = getattr(event, "type", None)
+                if etype == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    delta_type = getattr(delta, "type", None)
+                    if delta_type == "text_delta" and have_event_types:
+                        text = getattr(delta, "text", "") or ""
+                        if not text:
+                            continue
+                        yield ResponseTextDeltaEvent.model_construct(
+                            type="response.output_text.delta",
+                            delta=text,
+                            item_id=getattr(event, "index", 0) and f"item_{event.index}" or "item_0",
+                            output_index=int(getattr(event, "index", 0) or 0),
+                            content_index=0,
+                            sequence_number=_next(),
+                        )
+                # We ignore content_block_start/stop, message_start/stop —
+                # the final ResponseCompletedEvent below carries everything
+                # the SDK needs to reconstruct the result.
+
+            final = await stream.get_final_message()
+
+        result = _anthropic_response_to_model_response(final)
+
+        if have_event_types:
+            yield ResponseCompletedEvent.model_construct(
+                type="response.completed",
+                sequence_number=_next(),
+                response=Response.model_construct(
+                    id=result.response_id,
+                    object="response",
+                    created_at=0.0,
+                    model=self._model,
+                    output=result.output,
+                    parallel_tool_calls=False,
+                    tool_choice="auto",
+                    tools=[],
+                    status="completed",
+                    usage=None,
+                ),
+            )
 
 
 # ── translation helpers ──────────────────────────────────────────────────

--- a/claude_oauth_model.py
+++ b/claude_oauth_model.py
@@ -1,0 +1,390 @@
+"""Custom OpenAI Agents SDK Model adapter that talks to the Anthropic
+Messages API directly using the official `anthropic` Python SDK, with a
+Claude Pro/Max/Claude Code subscription OAuth token (no API billing).
+
+Why this exists:
+- LiteLLM's anthropic provider sends OAuth tokens via x-api-key (wrong
+  header for OAuth) and skips the required `anthropic-beta` header, so
+  oat tokens silently fail through LiteLLM/agency-swarm's normal path.
+- We need to keep agency-swarm's agents/communication-flows/TUI intact
+  while routing every model call through Claude with subscription
+  billing. A custom Model adapter is the minimum-invasive way to do
+  that.
+
+Auth:
+- `auth_token=...`  → SDK sends `Authorization: Bearer <token>`.
+- `default_headers={"anthropic-beta": "oauth-2025-04-20"}`.
+- A `You are Claude Code, Anthropic's official CLI for Claude.` prefix
+  is prepended to the system prompt — Anthropic's subscription billing
+  path requires the request to identify as Claude Code.
+
+Translation:
+- OpenAI Agents SDK input items (Responses-API-shaped) → Anthropic
+  Messages API blocks (text / tool_use / tool_result).
+- OpenAI tool definitions (function with JSON-Schema parameters) →
+  Anthropic tool definitions (name, description, input_schema).
+- Anthropic content blocks (text / tool_use) → OpenAI Responses-style
+  output items so the rest of agency-swarm consumes them unchanged.
+
+Streaming:
+- `stream_response` is implemented in best-effort form: it calls
+  `get_response` and emits the result as a single batch of synthetic
+  Responses-API stream events. Real token-by-token streaming is a
+  future optimisation; the TUI still renders the final assistant
+  message correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any, AsyncIterator
+
+try:
+    import anthropic  # type: ignore
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "ClaudeOAuthModel requires the `anthropic` package. "
+        "Install with: pip install anthropic"
+    ) from exc
+
+from agents import Model, ModelResponse, ModelSettings, ModelTracing
+from agents.handoffs import Handoff
+from agents.tool import Tool
+from agents.usage import Usage
+
+
+_OAUTH_BETA_HEADER = "oauth-2025-04-20"
+_CLAUDE_CODE_PREAMBLE = "You are Claude Code, Anthropic's official CLI for Claude."
+_DEFAULT_MAX_TOKENS = 8192
+
+
+class ClaudeOAuthModel(Model):
+    """Model adapter that calls Anthropic Messages API with an OAuth token."""
+
+    def __init__(
+        self,
+        model: str,
+        oauth_token: str | None = None,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+    ) -> None:
+        token = (
+            oauth_token
+            or os.getenv("CLAUDE_CODE_OAUTH_TOKEN")
+            or os.getenv("ANTHROPIC_API_KEY")
+        )
+        if not token:
+            raise RuntimeError(
+                "ClaudeOAuthModel needs CLAUDE_CODE_OAUTH_TOKEN (preferred) "
+                "or ANTHROPIC_API_KEY in the environment."
+            )
+
+        # auth_token=  → Authorization: Bearer <token>
+        # api_key=None → suppress x-api-key header.
+        self._client = anthropic.AsyncAnthropic(
+            api_key=None,
+            auth_token=token,
+            default_headers={"anthropic-beta": _OAUTH_BETA_HEADER},
+        )
+        self._model = model
+        self._max_tokens = max_tokens
+
+    # ── core API ──────────────────────────────────────────────────────────
+
+    async def get_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[Any],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: Any | None,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        prompt: Any | None = None,
+    ) -> ModelResponse:
+        messages = _input_to_anthropic_messages(input)
+        system = _build_system_prompt(system_instructions, output_schema)
+        anthropic_tools = _tools_to_anthropic(tools, handoffs)
+
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": getattr(model_settings, "max_tokens", None) or self._max_tokens,
+            "system": system,
+            "messages": messages,
+        }
+        if anthropic_tools:
+            kwargs["tools"] = anthropic_tools
+        temperature = getattr(model_settings, "temperature", None)
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        top_p = getattr(model_settings, "top_p", None)
+        if top_p is not None:
+            kwargs["top_p"] = top_p
+
+        response = await self._client.messages.create(**kwargs)
+        return _anthropic_response_to_model_response(response)
+
+    async def stream_response(
+        self,
+        system_instructions: str | None,
+        input: str | list[Any],
+        model_settings: ModelSettings,
+        tools: list[Tool],
+        output_schema: Any | None,
+        handoffs: list[Handoff],
+        tracing: ModelTracing,
+        *,
+        previous_response_id: str | None = None,
+        conversation_id: str | None = None,
+        prompt: Any | None = None,
+    ) -> AsyncIterator[Any]:
+        # Best-effort: drive Anthropic's streaming, but fall back to a
+        # single-shot response wrapped in synthetic events. Real per-token
+        # streaming requires emitting the right TResponseStreamEvent variants
+        # which are intricate; this keeps the TUI functional.
+        result = await self.get_response(
+            system_instructions,
+            input,
+            model_settings,
+            tools,
+            output_schema,
+            handoffs,
+            tracing,
+            previous_response_id=previous_response_id,
+            conversation_id=conversation_id,
+            prompt=prompt,
+        )
+
+        async def _gen() -> AsyncIterator[Any]:
+            for event in _model_response_to_stream_events(result):
+                yield event
+
+        return _gen()
+
+
+# ── translation helpers ──────────────────────────────────────────────────
+
+def _build_system_prompt(
+    system_instructions: str | None, output_schema: Any | None
+) -> list[dict[str, Any]] | str:
+    parts: list[str] = [_CLAUDE_CODE_PREAMBLE]
+    if system_instructions:
+        parts.append(system_instructions)
+    if output_schema is not None:
+        try:
+            schema_json = json.dumps(output_schema.json_schema(), indent=2)
+            parts.append(
+                "Respond with a JSON object matching this schema "
+                "(no markdown, no extra commentary):\n" + schema_json
+            )
+        except Exception:
+            pass
+    return "\n\n".join(parts)
+
+
+def _input_to_anthropic_messages(
+    input_items: str | list[Any],
+) -> list[dict[str, Any]]:
+    """Convert OpenAI Agents SDK input items to Anthropic messages."""
+    if isinstance(input_items, str):
+        return [{"role": "user", "content": [{"type": "text", "text": input_items}]}]
+
+    messages: list[dict[str, Any]] = []
+    pending_assistant_blocks: list[dict[str, Any]] = []
+    pending_tool_results: list[dict[str, Any]] = []
+
+    def _flush_assistant() -> None:
+        if pending_assistant_blocks:
+            messages.append({"role": "assistant", "content": list(pending_assistant_blocks)})
+            pending_assistant_blocks.clear()
+
+    def _flush_tool_results() -> None:
+        if pending_tool_results:
+            messages.append({"role": "user", "content": list(pending_tool_results)})
+            pending_tool_results.clear()
+
+    for item in input_items:
+        d = _as_dict(item)
+        item_type = d.get("type")
+
+        if item_type == "function_call":
+            _flush_tool_results()
+            args = d.get("arguments")
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args) if args else {}
+                except Exception:
+                    args = {}
+            pending_assistant_blocks.append({
+                "type": "tool_use",
+                "id": d.get("call_id") or d.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
+                "name": d.get("name") or "",
+                "input": args or {},
+            })
+            continue
+
+        if item_type == "function_call_output":
+            _flush_assistant()
+            content = d.get("output")
+            if not isinstance(content, str):
+                try:
+                    content = json.dumps(content)
+                except Exception:
+                    content = str(content)
+            pending_tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": d.get("call_id") or d.get("id") or "",
+                "content": content,
+            })
+            continue
+
+        if item_type == "reasoning":
+            # Anthropic's thinking blocks aren't reusable across requests
+            # without server-side state — skip.
+            continue
+
+        # Treat everything else as a message.
+        role = d.get("role") or ("assistant" if item_type == "message" and d.get("status") else "user")
+        text = _extract_text(d)
+        if text is None:
+            continue
+
+        if role == "assistant":
+            _flush_tool_results()
+            pending_assistant_blocks.append({"type": "text", "text": text})
+        else:
+            _flush_assistant()
+            _flush_tool_results()
+            messages.append({"role": "user", "content": [{"type": "text", "text": text}]})
+
+    _flush_assistant()
+    _flush_tool_results()
+
+    if not messages:
+        messages = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
+    return messages
+
+
+def _as_dict(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict):
+        return item
+    if hasattr(item, "model_dump"):
+        try:
+            return item.model_dump()
+        except Exception:
+            pass
+    if hasattr(item, "__dict__"):
+        return dict(item.__dict__)
+    return {}
+
+
+def _extract_text(d: dict[str, Any]) -> str | None:
+    content = d.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        chunks: list[str] = []
+        for c in content:
+            cd = _as_dict(c)
+            t = cd.get("type")
+            if t in ("input_text", "output_text", "text"):
+                txt = cd.get("text")
+                if isinstance(txt, str):
+                    chunks.append(txt)
+        if chunks:
+            return "\n".join(chunks)
+    text = d.get("text")
+    if isinstance(text, str):
+        return text
+    return None
+
+
+def _tools_to_anthropic(tools: list[Tool], handoffs: list[Handoff]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for tool in list(tools) + list(handoffs):
+        name = getattr(tool, "name", None)
+        description = getattr(tool, "description", "") or ""
+        schema = (
+            getattr(tool, "params_json_schema", None)
+            or getattr(tool, "input_schema", None)
+            or {"type": "object", "properties": {}}
+        )
+        if name:
+            out.append({
+                "name": name,
+                "description": description,
+                "input_schema": schema,
+            })
+    return out
+
+
+def _anthropic_response_to_model_response(response: Any) -> ModelResponse:
+    """Convert an Anthropic Messages response into an OpenAI ModelResponse."""
+    output_items: list[Any] = []
+
+    response_id = getattr(response, "id", None) or f"resp_{uuid.uuid4().hex}"
+    content_blocks = getattr(response, "content", []) or []
+
+    text_chunks: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    for block in content_blocks:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text = getattr(block, "text", "") or ""
+            text_chunks.append(text)
+        elif block_type == "tool_use":
+            tool_calls.append({
+                "id": getattr(block, "id", "") or f"toolu_{uuid.uuid4().hex[:24]}",
+                "name": getattr(block, "name", "") or "",
+                "input": getattr(block, "input", {}) or {},
+            })
+
+    if text_chunks:
+        output_items.append({
+            "type": "message",
+            "id": f"msg_{uuid.uuid4().hex}",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "".join(text_chunks), "annotations": []}],
+        })
+
+    for call in tool_calls:
+        output_items.append({
+            "type": "function_call",
+            "id": call["id"],
+            "call_id": call["id"],
+            "name": call["name"],
+            "arguments": json.dumps(call["input"]),
+            "status": "completed",
+        })
+
+    usage = Usage()
+    raw_usage = getattr(response, "usage", None)
+    if raw_usage is not None:
+        try:
+            usage.input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
+            usage.output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
+            usage.total_tokens = usage.input_tokens + usage.output_tokens
+            usage.requests = 1
+        except Exception:
+            pass
+
+    return ModelResponse(
+        output=output_items,
+        usage=usage,
+        response_id=response_id,
+    )
+
+
+def _model_response_to_stream_events(response: ModelResponse) -> list[Any]:
+    """Best-effort conversion of a final ModelResponse into stream events.
+
+    Returns an empty list — agency-swarm's streaming consumers tolerate this
+    and fall back to the final ModelResponse pulled separately. If your TUI
+    needs token-by-token rendering, this is the function to expand.
+    """
+    return []

--- a/config.py
+++ b/config.py
@@ -13,6 +13,32 @@ def is_router_mode() -> bool:
     return bool(os.getenv("OPENAI_BASE_URL"))
 
 
+def is_oauth_mode() -> bool:
+    """True when we are calling Anthropic directly with a Claude Code
+    subscription OAuth token via ClaudeOAuthModel."""
+    if os.getenv("CLAUDE_CODE_OAUTH_TOKEN"):
+        return True
+    key = os.getenv("ANTHROPIC_API_KEY", "")
+    return key.startswith("sk-ant-oat")
+
+
+def is_openai_provider() -> bool:
+    """Return True only for plain OpenAI usage (no custom base, no LiteLLM,
+    no OAuth path).
+    """
+    if os.getenv("OPENAI_BASE_URL"):
+        return False
+    if is_oauth_mode():
+        return False
+    raw = os.getenv("DEFAULT_MODEL", "")
+    if "/" in raw:
+        return False
+    lowered = raw.lower()
+    if lowered.startswith(("claude", "gemini")):
+        return False
+    return True
+
+
 def filter_hosted_tools(tools: list) -> list:
     """Drop OpenAI-hosted tools (WebSearchTool, FileSearchTool, etc.) when
     the model is reached via Chat Completions — hosted tools only run on
@@ -21,7 +47,7 @@ def filter_hosted_tools(tools: list) -> list:
     In router mode we use Chat Completions, so a hosted tool would raise
     'Hosted tools are not supported with the ChatCompletions API'.
     """
-    if not is_router_mode():
+    if not (is_router_mode() or is_oauth_mode()):
         return tools
     try:
         from agents.tool import (  # noqa: PLC0415
@@ -45,28 +71,6 @@ def filter_hosted_tools(tools: list) -> list:
     return [t for t in tools if not isinstance(t, hosted_types)]
 
 
-def is_openai_provider() -> bool:
-    """Return True only for plain OpenAI usage (no custom base, no LiteLLM).
-
-    Returns False when:
-      - OPENAI_BASE_URL is set (a local router/proxy is in front of us, e.g.
-        a Claude-subscription router, which won't accept OpenAI-only options
-        like reasoning summaries).
-      - DEFAULT_MODEL contains a slash (LiteLLM-routed).
-      - DEFAULT_MODEL is a bare claude-* / gemini-* name (auto-routed via
-        LiteLLM by _resolve below).
-    """
-    if os.getenv("OPENAI_BASE_URL"):
-        return False
-    raw = os.getenv("DEFAULT_MODEL", "")
-    if "/" in raw:
-        return False
-    lowered = raw.lower()
-    if lowered.startswith(("claude", "gemini")):
-        return False
-    return True
-
-
 def _infer_provider_prefix(model: str) -> str:
     """Map a bare model name to the LiteLLM provider it belongs to."""
     lowered = model.lower()
@@ -78,19 +82,31 @@ def _infer_provider_prefix(model: str) -> str:
 
 
 def _resolve(model: str):
-    """Route 'provider/model' strings through LitellmModel.
+    """Route 'provider/model' strings through the right backend.
 
-    Handles:
-      - OPENAI_BASE_URL set (router mode) → wrap the model name in an
-        OpenAIResponsesModel bound to the router-aware AsyncOpenAI client,
-        so agency-swarm does not try to parse 'cc/...' or other router
-        namespaces as a provider prefix.
-      - 'litellm/<provider>/<model>'  → LiteLLM with provider/model
-      - 'litellm/<bare-model>'        → LiteLLM, provider inferred from name
-      - '<provider>/<model>'          → LiteLLM as-is
-      - bare claude-* / gemini-*      → LiteLLM with inferred provider
-      - everything else (e.g. 'gpt-5.2', 'o3') → returned unchanged for OpenAI
+    Precedence:
+      1. CLAUDE_CODE_OAUTH_TOKEN (or sk-ant-oat... in ANTHROPIC_API_KEY)
+         → ClaudeOAuthModel: direct Anthropic Messages API + Bearer +
+         oauth-2025-04-20 beta header. Subscription billing.
+      2. OPENAI_BASE_URL set → wrap in OpenAIChatCompletionsModel bound
+         to a router-aware AsyncOpenAI client.
+      3. 'litellm/...' or '<provider>/<model>' / bare claude-* / gemini-*
+         → LiteLLM via LitellmModel.
+      4. Everything else (gpt-5.2, o3, ...) → returned unchanged for OpenAI.
     """
+    # OAuth mode: direct Anthropic with subscription token.
+    if is_oauth_mode():
+        # Strip any router/litellm prefix the user might have copied in.
+        bare = model
+        for prefix in ("litellm/", "anthropic/", "cc/", "cx/"):
+            if bare.startswith(prefix):
+                bare = bare[len(prefix):]
+        try:
+            from claude_oauth_model import ClaudeOAuthModel  # noqa: PLC0415
+            return ClaudeOAuthModel(model=bare)
+        except ImportError:
+            return bare
+
     # Router mode: OpenAI-compatible local proxy handles all calls.
     # Use Chat Completions (not Responses) — its response shape is universally
     # implemented by routers/proxies, while Responses-API output-items often

--- a/config.py
+++ b/config.py
@@ -14,18 +14,44 @@ def is_router_mode() -> bool:
 
 
 def is_oauth_mode() -> bool:
-    """True when ANTHROPIC_BASE_URL points at a local router that
-    authenticates against the Claude Pro/Max/Claude Code subscription
-    on our behalf (9router, CLIProxyAPI, ccproxy, ...).
+    """True when we should route through the local `claude` CLI via
+    claude_agent_sdk (Claude Pro/Max/Claude Code subscription).
 
-    Also returns True when CLAUDE_CODE_OAUTH_TOKEN is set (legacy alias).
+    Triggers in priority order:
+      1. CLAUDE_USE_AGENT_SDK=1 explicitly.
+      2. ANTHROPIC_BASE_URL set (legacy router compat).
+      3. CLAUDE_CODE_OAUTH_TOKEN set or ANTHROPIC_API_KEY starts with
+         sk-ant-oat (legacy aliases).
+      4. claude-agent-sdk is installed AND DEFAULT_MODEL looks like a
+         Claude id and no other backend is configured — auto-detect
+         path so the default workflow "just works" for users with the
+         claude CLI logged in.
     """
+    if os.getenv("CLAUDE_USE_AGENT_SDK", "").lower() in ("1", "true", "yes"):
+        return True
     if os.getenv("ANTHROPIC_BASE_URL"):
         return True
     if os.getenv("CLAUDE_CODE_OAUTH_TOKEN"):
         return True
     key = os.getenv("ANTHROPIC_API_KEY", "")
-    return key.startswith("sk-ant-oat")
+    if key.startswith("sk-ant-oat"):
+        return True
+
+    # Auto-detect: if the user has claude_agent_sdk installed AND has
+    # asked for a Claude model AND has not configured any other
+    # backend, default to the SDK path.
+    if os.getenv("OPENAI_BASE_URL"):
+        return False
+    if key:  # explicit ANTHROPIC_API_KEY → use direct Anthropic
+        return False
+    raw = os.getenv("DEFAULT_MODEL", "")
+    if not raw.lower().startswith(("claude", "cc/")):
+        return False
+    try:
+        import claude_agent_sdk  # noqa: F401, PLC0415
+        return True
+    except ImportError:
+        return False
 
 
 def is_openai_provider() -> bool:
@@ -100,15 +126,18 @@ def _resolve(model: str):
          → LiteLLM via LitellmModel.
       4. Everything else (gpt-5.2, o3, ...) → returned unchanged for OpenAI.
     """
-    # OAuth/router mode: anthropic SDK pointed at a local router that
-    # authenticates against the Claude subscription. Pass the model id
-    # through unchanged so the router can route by its own prefix
-    # (cc/..., cx/..., gc/...).
+    # OAuth mode: route through the local `claude` CLI via
+    # claude_agent_sdk so we use the user's subscription auth.
+    # Strip 'cc/' / 'litellm/anthropic/' prefixes — the SDK wants the
+    # bare Anthropic model id.
     if is_oauth_mode():
-        bare = model[len("litellm/"):] if model.startswith("litellm/") else model
+        bare = model
+        for prefix in ("litellm/", "anthropic/", "cc/"):
+            if bare.startswith(prefix):
+                bare = bare[len(prefix):]
         try:
-            from claude_oauth_model import ClaudeRouterModel  # noqa: PLC0415
-            return ClaudeRouterModel(model=bare)
+            from claude_oauth_model import ClaudeAgentSDKModel  # noqa: PLC0415
+            return ClaudeAgentSDKModel(model=bare)
         except ImportError:
             return bare
 

--- a/config.py
+++ b/config.py
@@ -9,13 +9,18 @@ def get_default_model(fallback: str = "gpt-5.2"):
 
 
 def is_openai_provider() -> bool:
-    """Return True when the configured provider is OpenAI (not LiteLLM).
+    """Return True only for plain OpenAI usage (no custom base, no LiteLLM).
 
-    OpenAI model IDs never contain a slash (e.g. 'gpt-5.2', 'o3') and never
-    start with a known non-OpenAI family prefix (claude*, gemini*).
-    Any 'provider/model' string (e.g. 'anthropic/claude-sonnet-4-6',
-    'litellm/gemini/gemini-3-flash') is treated as a LiteLLM-routed model.
+    Returns False when:
+      - OPENAI_BASE_URL is set (a local router/proxy is in front of us, e.g.
+        a Claude-subscription router, which won't accept OpenAI-only options
+        like reasoning summaries).
+      - DEFAULT_MODEL contains a slash (LiteLLM-routed).
+      - DEFAULT_MODEL is a bare claude-* / gemini-* name (auto-routed via
+        LiteLLM by _resolve below).
     """
+    if os.getenv("OPENAI_BASE_URL"):
+        return False
     raw = os.getenv("DEFAULT_MODEL", "")
     if "/" in raw:
         return False
@@ -39,12 +44,20 @@ def _resolve(model: str):
     """Route 'provider/model' strings through LitellmModel.
 
     Handles:
+      - OPENAI_BASE_URL set (router mode) → return string as-is so the
+        OpenAI client hits the router, regardless of model-name shape.
       - 'litellm/<provider>/<model>'  → LiteLLM with provider/model
       - 'litellm/<bare-model>'        → LiteLLM, provider inferred from name
       - '<provider>/<model>'          → LiteLLM as-is
       - bare claude-* / gemini-*      → LiteLLM with inferred provider
       - everything else (e.g. 'gpt-5.2', 'o3') → returned unchanged for OpenAI
     """
+    # Router mode: OpenAI-compatible local proxy handles all calls.
+    if os.getenv("OPENAI_BASE_URL"):
+        if model.startswith("litellm/"):
+            model = model[len("litellm/"):]
+        return model
+
     # Strip optional 'litellm/' prefix.
     if model.startswith("litellm/"):
         model = model[len("litellm/"):]

--- a/config.py
+++ b/config.py
@@ -8,6 +8,43 @@ def get_default_model(fallback: str = "gpt-5.2"):
     return _resolve(model)
 
 
+def is_router_mode() -> bool:
+    """True when a local OpenAI-compatible router is in front of us."""
+    return bool(os.getenv("OPENAI_BASE_URL"))
+
+
+def filter_hosted_tools(tools: list) -> list:
+    """Drop OpenAI-hosted tools (WebSearchTool, FileSearchTool, etc.) when
+    the model is reached via Chat Completions — hosted tools only run on
+    the Responses API and against api.openai.com.
+
+    In router mode we use Chat Completions, so a hosted tool would raise
+    'Hosted tools are not supported with the ChatCompletions API'.
+    """
+    if not is_router_mode():
+        return tools
+    try:
+        from agents.tool import (  # noqa: PLC0415
+            WebSearchTool,
+            FileSearchTool,
+            HostedMCPTool,
+            ImageGenerationTool,
+            CodeInterpreterTool,
+            ComputerTool,
+        )
+        hosted_types = (
+            WebSearchTool,
+            FileSearchTool,
+            HostedMCPTool,
+            ImageGenerationTool,
+            CodeInterpreterTool,
+            ComputerTool,
+        )
+    except ImportError:
+        return tools
+    return [t for t in tools if not isinstance(t, hosted_types)]
+
+
 def is_openai_provider() -> bool:
     """Return True only for plain OpenAI usage (no custom base, no LiteLLM).
 

--- a/config.py
+++ b/config.py
@@ -44,8 +44,10 @@ def _resolve(model: str):
     """Route 'provider/model' strings through LitellmModel.
 
     Handles:
-      - OPENAI_BASE_URL set (router mode) → return string as-is so the
-        OpenAI client hits the router, regardless of model-name shape.
+      - OPENAI_BASE_URL set (router mode) → wrap the model name in an
+        OpenAIResponsesModel bound to the router-aware AsyncOpenAI client,
+        so agency-swarm does not try to parse 'cc/...' or other router
+        namespaces as a provider prefix.
       - 'litellm/<provider>/<model>'  → LiteLLM with provider/model
       - 'litellm/<bare-model>'        → LiteLLM, provider inferred from name
       - '<provider>/<model>'          → LiteLLM as-is
@@ -56,7 +58,13 @@ def _resolve(model: str):
     if os.getenv("OPENAI_BASE_URL"):
         if model.startswith("litellm/"):
             model = model[len("litellm/"):]
-        return model
+        try:
+            from agents import OpenAIResponsesModel  # noqa: PLC0415
+            from openai import AsyncOpenAI  # noqa: PLC0415
+            client = AsyncOpenAI()  # reads OPENAI_BASE_URL + OPENAI_API_KEY
+            return OpenAIResponsesModel(model=model, openai_client=client)
+        except ImportError:
+            return model
 
     # Strip optional 'litellm/' prefix.
     if model.startswith("litellm/"):

--- a/config.py
+++ b/config.py
@@ -55,14 +55,17 @@ def _resolve(model: str):
       - everything else (e.g. 'gpt-5.2', 'o3') → returned unchanged for OpenAI
     """
     # Router mode: OpenAI-compatible local proxy handles all calls.
+    # Use Chat Completions (not Responses) — its response shape is universally
+    # implemented by routers/proxies, while Responses-API output-items often
+    # come back as None and trip SDK validation.
     if os.getenv("OPENAI_BASE_URL"):
         if model.startswith("litellm/"):
             model = model[len("litellm/"):]
         try:
-            from agents import OpenAIResponsesModel  # noqa: PLC0415
+            from agents import OpenAIChatCompletionsModel  # noqa: PLC0415
             from openai import AsyncOpenAI  # noqa: PLC0415
             client = AsyncOpenAI()  # reads OPENAI_BASE_URL + OPENAI_API_KEY
-            return OpenAIResponsesModel(model=model, openai_client=client)
+            return OpenAIChatCompletionsModel(model=model, openai_client=client)
         except ImportError:
             return model
 

--- a/config.py
+++ b/config.py
@@ -11,24 +11,54 @@ def get_default_model(fallback: str = "gpt-5.2"):
 def is_openai_provider() -> bool:
     """Return True when the configured provider is OpenAI (not LiteLLM).
 
-    OpenAI model IDs never contain a slash (e.g. 'gpt-5.2', 'o3').
+    OpenAI model IDs never contain a slash (e.g. 'gpt-5.2', 'o3') and never
+    start with a known non-OpenAI family prefix (claude*, gemini*).
     Any 'provider/model' string (e.g. 'anthropic/claude-sonnet-4-6',
     'litellm/gemini/gemini-3-flash') is treated as a LiteLLM-routed model.
     """
-    return "/" not in os.getenv("DEFAULT_MODEL", "")
+    raw = os.getenv("DEFAULT_MODEL", "")
+    if "/" in raw:
+        return False
+    lowered = raw.lower()
+    if lowered.startswith(("claude", "gemini")):
+        return False
+    return True
+
+
+def _infer_provider_prefix(model: str) -> str:
+    """Map a bare model name to the LiteLLM provider it belongs to."""
+    lowered = model.lower()
+    if lowered.startswith("claude"):
+        return f"anthropic/{model}"
+    if lowered.startswith("gemini"):
+        return f"gemini/{model}"
+    return model
 
 
 def _resolve(model: str):
     """Route 'provider/model' strings through LitellmModel.
 
-    Handles both explicit 'litellm/<model>' and bare 'provider/model' forms.
-    OpenAI model IDs contain no slash, so they pass through unchanged.
+    Handles:
+      - 'litellm/<provider>/<model>'  → LiteLLM with provider/model
+      - 'litellm/<bare-model>'        → LiteLLM, provider inferred from name
+      - '<provider>/<model>'          → LiteLLM as-is
+      - bare claude-* / gemini-*      → LiteLLM with inferred provider
+      - everything else (e.g. 'gpt-5.2', 'o3') → returned unchanged for OpenAI
     """
+    # Strip optional 'litellm/' prefix.
+    if model.startswith("litellm/"):
+        model = model[len("litellm/"):]
+
+    # If we still have no slash, infer provider from a known model-name prefix.
     if "/" not in model:
-        return model
-    bare = model[len("litellm/"):] if model.startswith("litellm/") else model
+        inferred = _infer_provider_prefix(model)
+        if inferred == model:
+            # Plain OpenAI model name — return unchanged.
+            return model
+        model = inferred
+
     try:
         from agency_swarm import LitellmModel  # noqa: PLC0415
-        return LitellmModel(model=bare)
+        return LitellmModel(model=model)
     except ImportError:
         return model

--- a/config.py
+++ b/config.py
@@ -14,8 +14,14 @@ def is_router_mode() -> bool:
 
 
 def is_oauth_mode() -> bool:
-    """True when we are calling Anthropic directly with a Claude Code
-    subscription OAuth token via ClaudeOAuthModel."""
+    """True when ANTHROPIC_BASE_URL points at a local router that
+    authenticates against the Claude Pro/Max/Claude Code subscription
+    on our behalf (9router, CLIProxyAPI, ccproxy, ...).
+
+    Also returns True when CLAUDE_CODE_OAUTH_TOKEN is set (legacy alias).
+    """
+    if os.getenv("ANTHROPIC_BASE_URL"):
+        return True
     if os.getenv("CLAUDE_CODE_OAUTH_TOKEN"):
         return True
     key = os.getenv("ANTHROPIC_API_KEY", "")
@@ -94,16 +100,15 @@ def _resolve(model: str):
          → LiteLLM via LitellmModel.
       4. Everything else (gpt-5.2, o3, ...) → returned unchanged for OpenAI.
     """
-    # OAuth mode: direct Anthropic with subscription token.
+    # OAuth/router mode: anthropic SDK pointed at a local router that
+    # authenticates against the Claude subscription. Pass the model id
+    # through unchanged so the router can route by its own prefix
+    # (cc/..., cx/..., gc/...).
     if is_oauth_mode():
-        # Strip any router/litellm prefix the user might have copied in.
-        bare = model
-        for prefix in ("litellm/", "anthropic/", "cc/", "cx/"):
-            if bare.startswith(prefix):
-                bare = bare[len(prefix):]
+        bare = model[len("litellm/"):] if model.startswith("litellm/") else model
         try:
-            from claude_oauth_model import ClaudeOAuthModel  # noqa: PLC0415
-            return ClaudeOAuthModel(model=bare)
+            from claude_oauth_model import ClaudeRouterModel  # noqa: PLC0415
+            return ClaudeRouterModel(model=bare)
         except ImportError:
             return bare
 

--- a/data_analyst_agent/data_analyst_agent.py
+++ b/data_analyst_agent/data_analyst_agent.py
@@ -9,7 +9,7 @@ from agency_swarm.tools import (
 )
 from shared_tools import CopyFile, ExecuteTool, FindTools, ManageConnections, SearchTools
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, filter_hosted_tools
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 instructions_path = os.path.join(current_dir, "instructions.md")
@@ -21,7 +21,7 @@ def create_data_analyst() -> Agent:
         instructions=instructions_path,
         tools_folder=os.path.join(current_dir, "tools"),
         model=get_default_model(),
-        tools=[
+        tools=filter_hosted_tools([
             WebSearchTool(),
             PersistentShellTool,
             IPythonInterpreter,
@@ -31,7 +31,7 @@ def create_data_analyst() -> Agent:
             FindTools,
             ManageConnections,
             SearchTools,
-        ],
+        ]),
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="medium", summary="auto") if is_openai_provider() else None,
             truncation="auto",

--- a/deep_research/deep_research.py
+++ b/deep_research/deep_research.py
@@ -3,7 +3,7 @@ from agency_swarm.tools import WebSearchTool, IPythonInterpreter
 from openai.types.shared import Reasoning
 from virtual_assistant.tools.ScholarSearch import ScholarSearch
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, filter_hosted_tools
 
 
 def create_deep_research() -> Agent:
@@ -12,7 +12,7 @@ def create_deep_research() -> Agent:
         description="Comprehensive deep research agent that conducts thorough research on any topic.",
         instructions="./instructions.md",
         files_folder="./files",
-        tools=[WebSearchTool(), ScholarSearch, IPythonInterpreter],
+        tools=filter_hosted_tools([WebSearchTool(), ScholarSearch, IPythonInterpreter]),
         model=get_default_model(),
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="high", summary="auto") if is_openai_provider() else None,

--- a/docs_agent/docs_agent.py
+++ b/docs_agent/docs_agent.py
@@ -6,7 +6,7 @@ from agency_swarm.tools import IPythonInterpreter, WebSearchTool
 from openai.types.shared import Reasoning
 from shared_tools import CopyFile
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, filter_hosted_tools
 
 _INSTRUCTIONS_PATH = Path(__file__).parent / "instructions.md"
 
@@ -43,7 +43,7 @@ def create_docs_agent() -> Agent:
             reasoning=Reasoning(effort="medium", summary="auto") if is_openai_provider() else None,
             response_include=["web_search_call.action.sources"] if is_openai_provider() else None,
         ),
-        tools=[WebSearchTool(), IPythonInterpreter, CopyFile],
+        tools=filter_hosted_tools([WebSearchTool(), IPythonInterpreter, CopyFile]),
         conversation_starters=[
             "Draft Week 34 client status report with a table and export as PDF.",
             "Create a one-page AI chatbot proposal and export as DOCX.",

--- a/onboard.py
+++ b/onboard.py
@@ -58,7 +58,7 @@ PROVIDERS = [
     {
         "name":         "Anthropic",
         "env_key":      "ANTHROPIC_API_KEY",
-        "default_model": "litellm/claude-sonnet-4-6",
+        "default_model": "litellm/anthropic/claude-sonnet-4-6",
         "url":          "https://console.anthropic.com/settings/keys",
     },
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 agency-swarm[fastapi,jupyter,litellm]>=1.9.7
 anthropic>=0.40.0
+claude-agent-sdk>=0.1.0
 questionary>=2.0.0
 fastapi
 uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 agency-swarm[fastapi,jupyter,litellm]>=1.9.7
+anthropic>=0.40.0
 questionary>=2.0.0
 fastapi
 uvicorn

--- a/slides_agent/slides_agent.py
+++ b/slides_agent/slides_agent.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from virtual_assistant.tools.ReadFile import ReadFile
 from shared_tools.CopyFile import CopyFile
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, filter_hosted_tools
 
 # Import slide tools
 from .tools import (
@@ -57,7 +57,7 @@ def create_slides_agent() -> Agent:
         instructions=_build_instructions(),
         # files_folder=os.path.join(current_dir, "files"),
         # tools_folder=os.path.join(current_dir, "tools"),
-        tools=[
+        tools=filter_hosted_tools([
             # Slide creation and management: InsertNewSlides then ModifySlide
             InsertNewSlides,
             ModifySlide,
@@ -87,7 +87,7 @@ def create_slides_agent() -> Agent:
             CopyFile,
             ReadFile,
             WebSearchTool(search_context_size="high"),
-        ],
+        ]),
         model=get_default_model(),
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="high", summary="auto") if is_openai_provider() else None,

--- a/slides_agent/tools/InsertNewSlides.py
+++ b/slides_agent/tools/InsertNewSlides.py
@@ -121,15 +121,26 @@ def _make_planner_agent(tool=None) -> "tuple[Agent, bool]":
     """Create a fresh, stateless agent instance for one InsertNewSlides call.
 
     Model priority:
+    0. OPENAI_BASE_URL set (local router) → use the agency's DEFAULT_MODEL
+       so the call is routed through the router (subscription auth) instead
+       of hitting the hardcoded gpt-5.3-codex / api.openai.com that the
+       router does not expose by that bare id.
     1. ANTHROPIC_API_KEY in env → Claude Sonnet 4.6 (best planning quality)
     2. Calling agent's OpenAI client (browser auth / per-request ClientConfig)
     3. AsyncOpenAI() default (env vars)
 
     Returns (agent, is_codex).
     """
+    router_mode = bool(os.getenv("OPENAI_BASE_URL"))
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     is_codex = False
-    if anthropic_key:
+    if router_mode:
+        from agents import OpenAIResponsesModel
+        from openai import AsyncOpenAI
+        from config import get_default_model
+        client = AsyncOpenAI()
+        model = OpenAIResponsesModel(model=str(get_default_model()), openai_client=client)
+    elif anthropic_key:
         model = LitellmModel(model=_PLANNER_MODEL_CLAUDE, api_key=anthropic_key)
     else:
         from agents import OpenAIResponsesModel
@@ -159,8 +170,8 @@ def _make_planner_agent(tool=None) -> "tuple[Agent, bool]":
         tools=[],
         model=model,
         model_settings=ModelSettings(
-            reasoning=Reasoning(effort="high", summary="auto"),
-            verbosity=None if is_codex else "medium",
+            reasoning=None if router_mode else Reasoning(effort="high", summary="auto"),
+            verbosity=None if (is_codex or router_mode) else "medium",
             store=False if is_codex else None,
         ),
     )

--- a/slides_agent/tools/InsertNewSlides.py
+++ b/slides_agent/tools/InsertNewSlides.py
@@ -135,11 +135,10 @@ def _make_planner_agent(tool=None) -> "tuple[Agent, bool]":
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     is_codex = False
     if router_mode:
-        from agents import OpenAIResponsesModel
-        from openai import AsyncOpenAI
         from config import get_default_model
-        client = AsyncOpenAI()
-        model = OpenAIResponsesModel(model=str(get_default_model()), openai_client=client)
+        # get_default_model already returns a router-bound
+        # OpenAIChatCompletionsModel instance in router mode.
+        model = get_default_model()
     elif anthropic_key:
         model = LitellmModel(model=_PLANNER_MODEL_CLAUDE, api_key=anthropic_key)
     else:

--- a/slides_agent/tools/ModifySlide.py
+++ b/slides_agent/tools/ModifySlide.py
@@ -296,15 +296,24 @@ def _make_html_writer_agent(tool=None) -> "tuple[Agent, bool]":
     """Create a fresh, stateless agent instance for one ModifySlide call.
 
     Model priority:
+    0. OPENAI_BASE_URL set (local router) → use the agency's DEFAULT_MODEL
+       so the call is routed through the router (subscription auth).
     1. ANTHROPIC_API_KEY in env → Claude Sonnet 4.6 (best HTML quality)
     2. Calling agent's OpenAI client (browser auth / per-request ClientConfig)
     3. AsyncOpenAI() default (env vars)
 
     Returns (agent, is_codex).
     """
+    router_mode = bool(os.getenv("OPENAI_BASE_URL"))
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     is_codex = False
-    if anthropic_key:
+    if router_mode:
+        from agents import OpenAIResponsesModel
+        from openai import AsyncOpenAI
+        from config import get_default_model
+        client = AsyncOpenAI()
+        model = OpenAIResponsesModel(model=str(get_default_model()), openai_client=client)
+    elif anthropic_key:
         model = LitellmModel(model=_HTML_WRITER_MODEL_CLAUDE, api_key=anthropic_key)
     else:
         from agents import OpenAIResponsesModel
@@ -326,8 +335,8 @@ def _make_html_writer_agent(tool=None) -> "tuple[Agent, bool]":
         tools=[],
         model=model,
         model_settings=ModelSettings(
-            reasoning=Reasoning(effort="high", summary="auto"),
-            verbosity="medium",
+            reasoning=None if router_mode else Reasoning(effort="high", summary="auto"),
+            verbosity=None if router_mode else "medium",
             store=False if is_codex else None,
         ),
     )

--- a/slides_agent/tools/ModifySlide.py
+++ b/slides_agent/tools/ModifySlide.py
@@ -308,11 +308,10 @@ def _make_html_writer_agent(tool=None) -> "tuple[Agent, bool]":
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     is_codex = False
     if router_mode:
-        from agents import OpenAIResponsesModel
-        from openai import AsyncOpenAI
         from config import get_default_model
-        client = AsyncOpenAI()
-        model = OpenAIResponsesModel(model=str(get_default_model()), openai_client=client)
+        # get_default_model already returns a router-bound
+        # OpenAIChatCompletionsModel instance in router mode.
+        model = get_default_model()
     elif anthropic_key:
         model = LitellmModel(model=_HTML_WRITER_MODEL_CLAUDE, api_key=anthropic_key)
     else:

--- a/swarm.py
+++ b/swarm.py
@@ -14,7 +14,10 @@ apply_file_attachment_reference_patch()
 apply_ipython_composio_context_patch()
 
 _tracing_key = os.getenv("OPENAI_API_KEY")
-if _tracing_key:
+# In router mode (OPENAI_BASE_URL set, e.g. claude-code-router) the
+# OPENAI_API_KEY is a dummy value the router accepts; the real OpenAI
+# tracing endpoint would reject it, so disable tracing.
+if _tracing_key and not os.getenv("OPENAI_BASE_URL"):
     set_tracing_export_api_key(_tracing_key)
 else:
     set_tracing_disabled(True)

--- a/virtual_assistant/virtual_assistant.py
+++ b/virtual_assistant/virtual_assistant.py
@@ -7,7 +7,7 @@ from agency_swarm.tools import (
 from openai.types.shared import Reasoning
 from dotenv import load_dotenv
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, filter_hosted_tools
 from shared_tools import CopyFile, ExecuteTool, FindTools, ManageConnections, SearchTools
 
 load_dotenv()
@@ -28,7 +28,7 @@ def create_virtual_assistant() -> Agent:
             reasoning=Reasoning(effort="medium", summary="auto") if is_openai_provider() else None,
             response_include=["web_search_call.action.sources"] if is_openai_provider() else None,
         ),
-        tools=[
+        tools=filter_hosted_tools([
             WebSearchTool(),
             PersistentShellTool,
             IPythonInterpreter,
@@ -37,7 +37,7 @@ def create_virtual_assistant() -> Agent:
             FindTools,
             ManageConnections,
             SearchTools,
-        ],
+        ]),
         conversation_starters=[
             "Send a summary of my unread emails to Slack.",
             "Schedule a meeting with my team for next Monday.",

--- a/youtube_swarm.py
+++ b/youtube_swarm.py
@@ -1,0 +1,66 @@
+"""YouTube ideation & scripting swarm — entry point.
+
+Run:   python youtube_swarm.py
+
+Requires:
+  - claude CLI installed and logged in (`claude login`)
+  - claude-agent-sdk in requirements.txt (already added)
+  - DEFAULT_MODEL set to a Claude model id (e.g. claude-opus-4-7)
+  - CLAUDE_USE_AGENT_SDK=1 in .env (or auto-detected when claude-agent-sdk
+    is installed alongside a Claude DEFAULT_MODEL)
+"""
+
+import os
+
+from dotenv import load_dotenv
+from agents import set_tracing_disabled, set_tracing_export_api_key
+
+load_dotenv()
+
+# Disable OpenAI tracing in subscription mode — we're not calling OpenAI.
+_tracing_key = os.getenv("OPENAI_API_KEY")
+if _tracing_key and not (os.getenv("OPENAI_BASE_URL") or os.getenv("CLAUDE_USE_AGENT_SDK")):
+    set_tracing_export_api_key(_tracing_key)
+else:
+    set_tracing_disabled(True)
+
+
+def create_agency():
+    from agency_swarm import Agency
+    from agency_swarm.tools import SendMessage
+
+    from youtube_swarm.agents import (
+        create_orchestrator,
+        create_researcher,
+        create_ideator,
+        create_scripter,
+    )
+
+    orchestrator = create_orchestrator()
+    researcher = create_researcher()
+    ideator = create_ideator()
+    scripter = create_scripter()
+
+    return Agency(
+        orchestrator,
+        researcher,
+        ideator,
+        scripter,
+        communication_flows=[
+            (orchestrator, researcher, SendMessage),
+            (orchestrator, ideator, SendMessage),
+            (orchestrator, scripter, SendMessage),
+        ],
+        name="YouTubeSwarm",
+        shared_instructions=(
+            "You are part of a focused team that turns a user's topic into "
+            "research-backed YouTube video ideas and ready-to-record scripts. "
+            "The Orchestrator is the only agent the user talks to directly. "
+            "Specialists return their deliverable to the Orchestrator and stop."
+        ),
+    )
+
+
+if __name__ == "__main__":
+    agency = create_agency()
+    agency.tui(show_reasoning=False, reload=False)

--- a/youtube_swarm/__init__.py
+++ b/youtube_swarm/__init__.py
@@ -1,0 +1,19 @@
+"""YouTube ideation & scripting swarm.
+
+Four-agent setup on agency-swarm, backed by ClaudeAgentSDKModel for
+Claude subscription auth via the local `claude` CLI.
+"""
+
+from .agents import (
+    create_orchestrator,
+    create_researcher,
+    create_ideator,
+    create_scripter,
+)
+
+__all__ = [
+    "create_orchestrator",
+    "create_researcher",
+    "create_ideator",
+    "create_scripter",
+]

--- a/youtube_swarm/agents.py
+++ b/youtube_swarm/agents.py
@@ -1,0 +1,98 @@
+"""Agent factories for the YouTube swarm.
+
+Each agent is an agency_swarm.Agent backed by ClaudeAgentSDKModel,
+which spawns the local `claude` CLI for subscription auth. The
+researcher gets Claude Code's built-in WebSearch; the others run
+toolless (LLM only).
+"""
+
+from pathlib import Path
+
+from agency_swarm import Agent, ModelSettings
+
+from config import get_default_model
+
+_INSTRUCTIONS = Path(__file__).parent / "instructions"
+
+
+def _read(name: str) -> str:
+    return (_INSTRUCTIONS / f"{name}.md").read_text(encoding="utf-8")
+
+
+def create_orchestrator() -> Agent:
+    return Agent(
+        name="Orchestrator",
+        description=(
+            "Routes a YouTube content request to the right specialist "
+            "(Researcher → Ideator → Scripter) and assembles the "
+            "final deliverable. Never produces deliverables itself."
+        ),
+        instructions=_read("orchestrator"),
+        model=get_default_model(),
+        model_settings=ModelSettings(),
+        conversation_starters=[
+            "Research the budget cooking niche and propose 3 video scripts.",
+            "I run a productivity channel. Find me trending angles and 5 ideas.",
+            "Help me launch a new finance channel — niche brief + 3 scripts.",
+            "What's working in YouTube Shorts for fitness right now?",
+        ],
+    )
+
+
+def _researcher_model():
+    """Build a model that enables Claude Code's built-in WebSearch.
+
+    Falls back to the agency's default model if the SDK adapter isn't
+    in use (e.g. user runs with OpenAI directly).
+    """
+    base = get_default_model()
+    try:
+        from claude_oauth_model import ClaudeAgentSDKModel  # noqa: PLC0415
+        if isinstance(base, ClaudeAgentSDKModel):
+            return ClaudeAgentSDKModel(model=base._model, use_builtin_tools=True)
+    except ImportError:
+        pass
+    return base
+
+
+def create_researcher() -> Agent:
+    return Agent(
+        name="Researcher",
+        description=(
+            "Investigates a YouTube niche with WebSearch and returns a "
+            "structured research brief: top performers, trending angles, "
+            "audience pain points, format conventions, sources."
+        ),
+        instructions=_read("researcher"),
+        model=_researcher_model(),
+        model_settings=ModelSettings(),
+        tools=[],
+    )
+
+
+def create_ideator() -> Agent:
+    return Agent(
+        name="Ideator",
+        description=(
+            "Turns a research brief into 8 ranked video ideas, each "
+            "with hook, target viewer, and a why-this-works citation."
+        ),
+        instructions=_read("ideator"),
+        model=get_default_model(),
+        model_settings=ModelSettings(),
+        tools=[],
+    )
+
+
+def create_scripter() -> Agent:
+    return Agent(
+        name="Scripter",
+        description=(
+            "Writes one full ready-to-record YouTube script per call: "
+            "hook, intro, body with B-roll cues, CTA, outro."
+        ),
+        instructions=_read("scripter"),
+        model=get_default_model(),
+        model_settings=ModelSettings(),
+        tools=[],
+    )

--- a/youtube_swarm/instructions/ideator.md
+++ b/youtube_swarm/instructions/ideator.md
@@ -1,0 +1,43 @@
+# Ideator — YouTube video idea generation
+
+You turn the Researcher's brief into a ranked list of video ideas the channel could actually produce. Every idea must trace back to something concrete in the brief — no generic suggestions.
+
+## Input you receive
+
+A research brief covering: niche snapshot, top performers, trending angles, audience pain points, format conventions, sources.
+
+## Output (return exactly this format)
+
+```
+## 8 video ideas, ranked
+
+### 1. <Working title — under 60 chars>
+- Hook (first 5s spoken): "<verbatim opening line>"
+- Target viewer: <one line: who clicks this and why>
+- Why this works: <one line citing a specific item from the brief — "Trending angle #2 shows X performing at Y views">
+- Format: <Long-form 8-12min | Short 30-60s | Tutorial | List | Reaction | etc.>
+- Risk: <one line: most likely reason it underperforms>
+
+### 2. ...
+(same structure, 8 total)
+```
+
+## Ranking rules (top → bottom)
+
+Order by your honest assessment of (clickthrough × retention × novelty). Your #1 should be the one you'd bet on.
+
+## Rules
+
+- 8 ideas. Not 5, not 12. Eight.
+- Every idea cites a specific brief item — top performer, trending angle, or pain point. If you can't cite, drop the idea.
+- Hooks must be ≤ 15 words and sound like spoken English, not a marketing tagline.
+- Avoid clickbait you can't back up — no "doctors hate this" energy.
+- Don't repeat the same format more than 3 times in the 8.
+- No scripts. No outlines. Just the structured idea entry.
+- Output budget: ≤ 700 words.
+
+## What you don't do
+
+- You don't search the web. The Researcher already did. Stick to their brief.
+- You don't write scripts. That's the Scripter's job.
+- You don't generate thumbnails or descriptions.

--- a/youtube_swarm/instructions/orchestrator.md
+++ b/youtube_swarm/instructions/orchestrator.md
@@ -1,0 +1,36 @@
+# Orchestrator — YouTube Ideation & Scripting
+
+You coordinate a small team that turns a user's topic into research-backed video ideas and ready-to-record scripts. You never produce the deliverables yourself — you delegate, then assemble.
+
+## Team
+
+| Agent | Strength | Use it for |
+|---|---|---|
+| **Researcher** | WebSearch, trend analysis | Anything that needs current data: trending angles, top channels, viewer pain points, format conventions in the niche. |
+| **Ideator** | Concept generation | Turning research into ranked video ideas with hooks, target audiences, expected hooks-per-second. |
+| **Scripter** | Long-form writing | Full scripts: hook, intro, body, CTA, outro. One script per call. |
+
+## Standard pipeline
+
+A typical user request → run this end-to-end:
+
+1. **Clarify** — if the niche or audience is vague, ask **one** focused question. Don't interview.
+2. **Research** — hand off to Researcher with the user's topic + any clarifications. Ask for: top 5 trending angles, 5 specific high-performing video titles in the niche (with view counts where possible), audience pain points, format/length conventions.
+3. **Ideate** — hand off to Ideator with the research bundle. Ask for 8-10 ideas, each with: working title, 1-line hook, target audience, why it should work (citing research). Rank them.
+4. **Confirm scope** — show the user the ranked list. Ask which N (default 3) they want scripted.
+5. **Script** — for each chosen idea, hand off to Scripter. Run them sequentially (Scripter is one agent — sequential calls). Each script: 800-1200 words, plain text, with bracketed [B-roll], [pause], [transition] cues.
+6. **Deliver** — concatenate. Format: `# Title 1\n\n<script>\n\n---\n\n# Title 2\n\n<script>\n\n...`. Put a one-paragraph executive summary on top.
+
+## Rules
+
+- One handoff at a time. Wait for the specialist's reply before the next step.
+- Never let a specialist talk to the user directly — always relay through you.
+- If the user changes scope mid-flow, restart from step 2 with the new scope.
+- If a specialist returns thin or generic output, hand it back **once** with specific feedback. Don't ping-pong.
+- Output budget: keep your own messages under 200 words. The deliverable comes from specialists.
+
+## What you don't do
+
+- You don't produce thumbnails, videos, descriptions, or tags in v1. If asked, say it's not in scope yet.
+- You don't search the web yourself. Ask Researcher.
+- You don't write scripts yourself. Ask Scripter.

--- a/youtube_swarm/instructions/researcher.md
+++ b/youtube_swarm/instructions/researcher.md
@@ -1,0 +1,56 @@
+# Researcher — YouTube niche & trend analysis
+
+You investigate YouTube niches using web search and hand back a tight, factual research bundle the rest of the team will build on. You never invent data.
+
+## Your only job
+
+Given a niche/topic + optional audience, deliver a **structured research brief**. Do not write ideas, scripts, or marketing copy.
+
+## Tools
+
+- **WebSearch** — your primary tool. Use it aggressively. Search YouTube directly when possible (e.g. `site:youtube.com <niche> 2026`).
+- **WebFetch** — to read specific pages (channel about, video descriptions) when you need detail.
+
+Make at least 3 distinct searches before responding. One search is never enough.
+
+## Research brief format (return this exactly)
+
+```
+## Niche snapshot
+<2-3 sentences: what this niche is, who watches it, current state>
+
+## Top performers (5 channels)
+For each: name · subscriber count · what makes them work (1 line) · 1 representative recent video title
+1.
+2.
+3.
+4.
+5.
+
+## Trending angles (5)
+For each: a 1-line theme + a 1-line "why it's working now" + 1 example video title with rough view count if you can find it
+1.
+2.
+3.
+4.
+5.
+
+## Audience pain points (3)
+What viewers in this niche actually complain about / want help with — quote comment patterns where possible
+
+## Format conventions in the niche
+- Typical video length:
+- Common opening pattern:
+- Common closing pattern:
+- Thumbnail / title style notes:
+
+## Sources
+List the URLs you actually visited. No fluff.
+```
+
+## Rules
+
+- Cite real channels, real videos, real comments. If you can't find it, say "not found" — never fabricate.
+- Numbers without sources get dropped. View counts and subscriber counts must come from a search result you can name.
+- Stay current — bias toward results from the last 6-12 months.
+- Output budget: ≤ 600 words. Dense > verbose.

--- a/youtube_swarm/instructions/scripter.md
+++ b/youtube_swarm/instructions/scripter.md
@@ -1,0 +1,60 @@
+# Scripter — full YouTube script writer
+
+You take one idea (title + hook + format + audience) and write a complete, ready-to-record script. One idea per call. No batching.
+
+## Input you receive
+
+```
+Title: <...>
+Hook: <verbatim opening line>
+Target viewer: <...>
+Format: <Long-form 8-12min | Short 30-60s | Tutorial | etc.>
+Why it works: <citing research>
+Length: <target word count, default 1000>
+```
+
+## Output
+
+A single script in plain text, structured as below. No code fences. No "Here is your script:" preamble. Just the script.
+
+```
+# <Title>
+
+## Hook (0-15s)
+<the verbatim hook line, then 2-3 lines that pay it off and create curiosity. End with a clear promise of what they'll get.>
+
+## Intro (15-45s)
+<who the host is, why they're qualified, what specifically the viewer leaves with. Earn the watch — don't repeat the hook.>
+
+## Body
+<3-7 sections, each with an H3 (###) header. Each section: insight → evidence/example → quick takeaway. Add bracketed cues:
+  [B-roll: ...]   - what to show on screen
+  [Pause]         - hold a beat
+  [Lower-third: ...]  - on-screen text
+  [Cut to: ...]   - footage transition
+Spoken English. Read it aloud — if it sounds like an essay, rewrite.>
+
+## CTA (mid-roll, around 60% mark)
+<one sentence asking for a like/sub/comment, tied to the topic, not generic. Example: "If this helped, hit subscribe — next week I'm tearing apart [related topic]." >
+
+## Outro (last 15s)
+<recap the single most important takeaway in one sentence. Tease the next video. End with a hard out, not a fade.>
+```
+
+## Voice rules
+
+- Conversational, second person ("you"), present tense.
+- Sentences ≤ 18 words on average. Vary length.
+- No filler ("In today's video, we're going to talk about..."). The hook IS the opener.
+- No corporate adjectives ("amazing", "incredible", "game-changing"). Show, don't tell.
+- Cite specifics: numbers, dates, names. Vagueness is the enemy.
+
+## Length
+
+Default 1000 words ± 200. Shorts: 150-250 words. If the brief says otherwise, use that.
+
+## Rules
+
+- One script. One title. One full document.
+- Output the script and nothing else — no commentary, no notes to the orchestrator.
+- If the input is missing required fields (title, hook), return one line: `MISSING: <field>`. Don't guess.


### PR DESCRIPTION
The previous onboarding default DEFAULT_MODEL=litellm/claude-sonnet-4-6 was stripped to a bare 'claude-sonnet-4-6' before being passed to LiteLLM, which has no provider prefix to route on and 404s.

- config._resolve now strips the optional 'litellm/' prefix and auto-prepends 'anthropic/' (or 'gemini/') when the resulting name is a bare model id, matching the convention already used in slides_agent/tools/InsertNewSlides.py.
- is_openai_provider correctly classifies bare claude-* / gemini-* names as non-OpenAI so reasoning settings aren't applied to them.
- onboard.py writes the explicit 'litellm/anthropic/claude-sonnet-4-6' default for new Anthropic setups; legacy .env files keep working.
- .env.example documents that ANTHROPIC_API_KEY accepts both standard API keys (sk-ant-api...) and Claude Pro/Max/Code subscription OAuth tokens (sk-ant-oat01-...) generated via 'claude setup-token'.