### PR TITLE
Add Azure OpenAI, Azure AI Foundry, Ollama, and OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,51 @@ ANTHROPIC_API_KEY=
 # Google Gemini — set this if using Google as your primary provider.
 GOOGLE_API_KEY=
 
+# Azure OpenAI Service — your own deployment of GPT-* on Azure.
+# Get keys from https://portal.azure.com (your AOAI resource → Keys & Endpoint).
+AZURE_API_KEY=
+AZURE_API_BASE=        # e.g. https://my-resource.openai.azure.com
+AZURE_API_VERSION=     # e.g. 2024-08-01-preview
+
+# Azure AI Foundry — catalog of Anthropic Claude (Opus, Sonnet), Llama, Mistral,
+# DeepSeek, and other non-OpenAI models. Get keys at https://ai.azure.com.
+# IMPORTANT: For Claude models, AZURE_AI_API_BASE must end with `/anthropic`
+# (e.g. https://my-resource.services.ai.azure.com/anthropic).
+# For other catalog models, use the bare resource URL.
+AZURE_AI_API_KEY=
+AZURE_AI_API_BASE=     # e.g. https://my-resource.services.ai.azure.com[/anthropic]
+
+# Ollama — local model server. No API key required; URL defaults to localhost.
+# Install + run from https://ollama.com, then `ollama pull <model>`.
+OLLAMA_API_BASE=       # default: http://localhost:11434
+
+# OpenAI-compatible — generic route for any vendor that exposes an
+# OpenAI-compatible API (Ollama Cloud, Groq, Together AI, Mistral La Plateforme,
+# OpenRouter, vLLM-based deployments, etc.). Uses dedicated env vars so it
+# never collides with a real OPENAI_API_KEY.
+# Examples:
+#   Groq:           OPENAI_COMPAT_API_BASE=https://api.groq.com/openai/v1
+#   Together AI:    OPENAI_COMPAT_API_BASE=https://api.together.xyz/v1
+#   Mistral:        OPENAI_COMPAT_API_BASE=https://api.mistral.ai/v1
+#   OpenRouter:     OPENAI_COMPAT_API_BASE=https://openrouter.ai/api/v1
+#   Ollama Cloud:   see https://docs.ollama.com for the current endpoint
+OPENAI_COMPAT_API_KEY=
+OPENAI_COMPAT_API_BASE=
+
 
 # ── Model selection ───────────────────────────
 
 # Override the default model for all agents (set automatically by onboarding).
-# OpenAI example:   DEFAULT_MODEL=gpt-5.2
-# Anthropic example: DEFAULT_MODEL=litellm/claude-sonnet-4-6
-# Google example:   DEFAULT_MODEL=litellm/gemini/gemini-3-flash
+# Use the `/switch-provider` flow inside the TUI to change this at runtime.
+# OpenAI example:        DEFAULT_MODEL=gpt-5.2
+# Anthropic example:     DEFAULT_MODEL=litellm/claude-sonnet-4-6
+# Google example:        DEFAULT_MODEL=litellm/gemini/gemini-3-flash
+# Azure OpenAI example:  DEFAULT_MODEL=azure/my-gpt5-deployment
+# Azure Foundry example: DEFAULT_MODEL=azure_ai/claude-opus-4-1
+#                         DEFAULT_MODEL=azure_ai/Llama-3.3-70B-Instruct
+# Ollama example:        DEFAULT_MODEL=ollama_chat/llama3.1
+# Ollama Cloud example:  DEFAULT_MODEL=openai_compat/qwen3-coder:480b-cloud
+# Groq example:          DEFAULT_MODEL=openai_compat/llama-3.3-70b-versatile
 DEFAULT_MODEL=
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ cython_debug/
 .agency_swarm/
 third_party/
 .claude/
+.omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,10 @@ The coding agent will read this file, understand the structure, and make the rig
 - `instructions.md` is the agent's system prompt — edit it to change behavior
 - Tools live in `tools/` and are auto-loaded by the agent definition
 - `shared_tools/` contains Composio-powered integrations (Gmail, Slack, GitHub, etc.) available to all agents
+- `orchestrator/tools/` holds tools that **only** the orchestrator gets — currently just `SwitchProvider`. Specialist agents must never import from this directory; the orchestrator's "router only" contract has one documented carve-out (provider switching) and that's it.
 - Models are configured via `DEFAULT_MODEL` in `.env` — never hardcoded
+- Provider routing: every supported provider is registered in `config.PROVIDER_REGISTRY` (a single source of truth). Adding a new provider means one entry there plus an optional UI entry in `onboard.PROVIDERS`.
+- Runtime provider switch: orchestrator users say "switch to <slug> <model>"; the `SwitchProvider` tool writes `.env` and signals `run_utils.main()` to rebuild the agency on next TUI exit. The FastAPI server at `server.py` does **not** read this signal — switching there is a no-op.
 
 Before proceeding with agent creation, please read the following instructions carefully:
 

--- a/README.md
+++ b/README.md
@@ -97,21 +97,31 @@ They'll automatically customize all agents for your use case.
 
 ## ⚙️ API Keys & Setup
 
-The setup wizard walks you through everything, but you'll need at least one of these:
+The setup wizard walks you through everything, but you'll need at least one of these.
 
-**Required (choose one):**
+**Pick a primary provider (one required):**
 
-- `OPENAI_API_KEY` - For GPT 5.5 and Sora video generation
-- `ANTHROPIC_API_KEY` - For Claude models
+- `OPENAI_API_KEY` — GPT 5.x and Sora video generation
+- `ANTHROPIC_API_KEY` — Claude models
+- `GOOGLE_API_KEY` — Gemini models (also drives image gen + Veo video)
+- **Azure OpenAI Service** — `AZURE_API_KEY` + `AZURE_API_BASE` + `AZURE_API_VERSION` for your own GPT deployment
+- **Azure AI Foundry** — `AZURE_AI_API_KEY` + `AZURE_AI_API_BASE` for the catalog (Claude on Azure, Llama, Mistral, DeepSeek, ...)
+- **Ollama (local)** — no key required; defaults to `http://localhost:11434`
+- **OpenAI-compatible** — `OPENAI_COMPAT_API_KEY` + `OPENAI_COMPAT_API_BASE` for Ollama Cloud, Groq, Together AI, Mistral La Plateforme, OpenRouter, vLLM
+
+Switching providers mid-session: ask the orchestrator "switch to ollama llama3.1" (or any other slug + model) — it routes to the `SwitchProvider` tool, writes the new `DEFAULT_MODEL` to `.env`, and on next TUI exit OpenSwarm restarts with the new provider.
 
 **Optional superpowers:**
 
-- `COMPOSIO_API_KEY` - Unlock 10,000+ integrations (Gmail, Slack, GitHub, etc.)
-- `GOOGLE_API_KEY` - Gemini image generation + Veo video
-- `FAL_KEY` - Advanced video editing and effects
-- `SEARCH_API_KEY` - Web search for research agent
+- `COMPOSIO_API_KEY` — Unlock 10,000+ integrations (Gmail, Slack, GitHub, etc.)
+- `FAL_KEY` — Advanced video editing and effects
+- `SEARCH_API_KEY` — Web search for research agent
 
 Tools gracefully degrade when keys are missing — you'll get clear instructions on what to add.
+
+### Upgrading from an earlier version
+
+If you already have a `.env` from before the multi-provider work, nothing breaks. Existing `DEFAULT_MODEL` values keep working: bare strings like `gpt-5.2` route to OpenAI directly, and `litellm/<model>` strings still route through LiteLLM. The wizard adds new variables for Azure, Ollama, and OpenAI-compatible setups; old keys stay in place. Re-run `python onboard.py` whenever you want to register a new provider.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,30 @@
-"""Shared model configuration helpers — read by all agents at startup."""
+"""Shared model configuration helpers — read by all agents at startup.
+
+PROVIDER_REGISTRY is the single source of truth for provider routing. Every
+new provider added to OpenSwarm should be registered here; the onboarding
+wizard and the SwitchProvider tool both derive their behavior from this
+table.
+"""
 import os
+
+# Slug -> routing spec. Adding a new provider means adding one entry here
+# and (optionally) a UI entry in onboard.PROVIDERS.
+#   prefix:        DEFAULT_MODEL prefix that identifies this provider
+#   required_env:  env vars that must be set before a model call works
+PROVIDER_REGISTRY: dict[str, dict] = {
+    "openai":        {"prefix": "",                "required_env": ["OPENAI_API_KEY"]},
+    # Anthropic models on LiteLLM are always named claude-*; using a more
+    # specific prefix here means a stray litellm/cohere/... model won't be
+    # misclassified as anthropic.
+    "anthropic":     {"prefix": "litellm/claude",  "required_env": ["ANTHROPIC_API_KEY"]},
+    "google":        {"prefix": "litellm/gemini/", "required_env": ["GOOGLE_API_KEY"]},
+    "azure":         {"prefix": "azure/",          "required_env": ["AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION"]},
+    "azure_ai":      {"prefix": "azure_ai/",       "required_env": ["AZURE_AI_API_KEY", "AZURE_AI_API_BASE"]},
+    "ollama":        {"prefix": "ollama_chat/",    "required_env": []},
+    # Only the base URL is strictly required — keyless endpoints (local vLLM,
+    # some OpenRouter / Mistral setups) are valid; LiteLLM passes None safely.
+    "openai_compat": {"prefix": "openai_compat/",  "required_env": ["OPENAI_COMPAT_API_BASE"]},
+}
 
 
 def get_default_model(fallback: str = "gpt-5.2"):
@@ -9,26 +34,75 @@ def get_default_model(fallback: str = "gpt-5.2"):
 
 
 def is_openai_provider() -> bool:
-    """Return True when the configured provider is OpenAI (not LiteLLM).
+    """True when DEFAULT_MODEL routes to OpenAI's hosted API directly.
 
-    OpenAI model IDs never contain a slash (e.g. 'gpt-5.2', 'o3').
-    Any 'provider/model' string (e.g. 'anthropic/claude-sonnet-4-6',
-    'litellm/gemini/gemini-3-flash') is treated as a LiteLLM-routed model.
+    OpenAI model IDs never contain a slash (e.g. 'gpt-5.2', 'o3'). Any
+    'provider/model' string is treated as a LiteLLM-routed model.
     """
     return "/" not in os.getenv("DEFAULT_MODEL", "")
+
+
+def get_active_provider() -> str:
+    """Slug derived from DEFAULT_MODEL by prefix table lookup.
+
+    Returns one of the slugs in PROVIDER_REGISTRY. Bare 'litellm/<model>'
+    strings that don't match anthropic (litellm/) or google (litellm/gemini/)
+    return 'unknown' so callers can distinguish 'I know this provider' from
+    'I don't recognize this'.
+    """
+    model = os.getenv("DEFAULT_MODEL", "")
+    if "/" not in model:
+        return "openai"
+    # Longest prefix wins so 'azure_ai/' matches before 'azure/' would.
+    for slug, spec in sorted(
+        PROVIDER_REGISTRY.items(), key=lambda kv: -len(kv[1]["prefix"])
+    ):
+        prefix = spec["prefix"]
+        if prefix and model.startswith(prefix):
+            return slug
+    return "unknown"
 
 
 def _resolve(model: str):
     """Route 'provider/model' strings through LitellmModel.
 
-    Handles both explicit 'litellm/<model>' and bare 'provider/model' forms.
-    OpenAI model IDs contain no slash, so they pass through unchanged.
+    Bare strings (no slash) pass through for OpenAI's hosted API. Strings
+    with a slash are wrapped in LitellmModel. The 'openai_compat/<model>'
+    sentinel unwraps to LiteLLM's openai/<model> route with dedicated
+    OPENAI_COMPAT_* credentials, so the user's real OPENAI_API_KEY is
+    never overwritten.
+
+    Raises RuntimeError if 'openai_compat/' is configured without
+    OPENAI_COMPAT_API_BASE — better to fail loudly at startup than give
+    a cryptic LiteLLM error on first call.
     """
     if "/" not in model:
         return model
+
+    if model.startswith("openai_compat/"):
+        real_model = "openai/" + model[len("openai_compat/"):]
+        api_key = os.getenv("OPENAI_COMPAT_API_KEY")
+        api_base = os.getenv("OPENAI_COMPAT_API_BASE")
+        if not api_base:
+            raise RuntimeError(
+                "DEFAULT_MODEL uses openai_compat/ but OPENAI_COMPAT_API_BASE "
+                "is not set. Run `python onboard.py` to configure it."
+            )
+        try:
+            from agency_swarm import LitellmModel  # noqa: PLC0415
+        except ImportError:
+            return real_model
+        return LitellmModel(model=real_model, api_key=api_key, base_url=api_base)
+
     bare = model[len("litellm/"):] if model.startswith("litellm/") else model
     try:
         from agency_swarm import LitellmModel  # noqa: PLC0415
-        return LitellmModel(model=bare)
     except ImportError:
         return model
+
+    # Thread Ollama's base URL explicitly. LiteLLM also reads OLLAMA_API_BASE
+    # from env, but passing it via base_url is unambiguous and consistent
+    # with the openai_compat branch.
+    if bare.startswith(("ollama/", "ollama_chat/")):
+        return LitellmModel(model=bare, base_url=os.getenv("OLLAMA_API_BASE"))
+    return LitellmModel(model=bare)

--- a/onboard.py
+++ b/onboard.py
@@ -48,24 +48,105 @@ if _HAS_QUESTIONARY:
     ])
 
 # ── provider definitions ──────────────────────────────────────────────────────
+# Each provider declares one or more env keys (`keys`) and a `default_model`
+# template. When the template contains `{model}`, the wizard asks the user for
+# the model/deployment name; otherwise the template is used as-is. Each key
+# spec supports: env, label, url (link to dashboard), help (one-line hint),
+# secret (default True), default (pre-fill).
 PROVIDERS = [
     {
-        "name":         "OpenAI",
-        "env_key":      "OPENAI_API_KEY",
+        "name":          "OpenAI",
         "default_model": "gpt-5.2",
-        "url":          "https://platform.openai.com/api-keys",
+        "keys": [
+            {"env": "OPENAI_API_KEY", "label": "OpenAI API key",
+             "url": "https://platform.openai.com/api-keys"},
+        ],
     },
     {
-        "name":         "Anthropic",
-        "env_key":      "ANTHROPIC_API_KEY",
+        "name":          "Anthropic",
         "default_model": "litellm/claude-sonnet-4-6",
-        "url":          "https://console.anthropic.com/settings/keys",
+        "keys": [
+            {"env": "ANTHROPIC_API_KEY", "label": "Anthropic API key",
+             "url": "https://console.anthropic.com/settings/keys"},
+        ],
     },
     {
-        "name":         "Google Gemini",
-        "env_key":      "GOOGLE_API_KEY",
+        "name":          "Google Gemini",
         "default_model": "litellm/gemini/gemini-3-flash",
-        "url":          "https://aistudio.google.com/app/apikey",
+        "keys": [
+            {"env": "GOOGLE_API_KEY", "label": "Google AI API key",
+             "url": "https://aistudio.google.com/app/apikey"},
+        ],
+    },
+    {
+        "name":          "Azure OpenAI Service",
+        "default_model": "azure/{model}",
+        "model_label":   "Azure deployment name",
+        "model_help":    "Name of your deployment in Azure (e.g. 'gpt-5.2-prod').",
+        "keys": [
+            {"env": "AZURE_API_KEY", "label": "Azure API key",
+             "url": "https://portal.azure.com"},
+            {"env": "AZURE_API_BASE", "label": "Azure endpoint URL",
+             "help": "https://<resource>.openai.azure.com", "secret": False},
+            {"env": "AZURE_API_VERSION", "label": "API version",
+             "default": "2024-08-01-preview", "secret": False},
+        ],
+    },
+    {
+        "name":          "Azure AI Foundry",
+        "default_model": "azure_ai/{model}",
+        "model_label":   "Foundry catalog model",
+        "model_help":    (
+            "Catalog name. Examples: 'claude-opus-4-1' or 'claude-sonnet-4-5' "
+            "(Anthropic), 'Llama-3.3-70B-Instruct', 'Mistral-large-2407', "
+            "'DeepSeek-V3'."
+        ),
+        "keys": [
+            {"env": "AZURE_AI_API_KEY", "label": "Azure AI Foundry key",
+             "url": "https://ai.azure.com"},
+            {"env": "AZURE_AI_API_BASE", "label": "Foundry endpoint URL",
+             "help": (
+                 "https://<resource>.services.ai.azure.com — append '/anthropic' "
+                 "for Claude models (e.g. https://my-resource.services.ai.azure.com/anthropic)."
+             ),
+             "secret": False},
+        ],
+    },
+    {
+        "name":          "Ollama (local)",
+        "default_model": "ollama_chat/{model}",
+        "model_label":   "Ollama model",
+        "model_help":    "A model you've already pulled (e.g. 'llama3.1', 'qwen2.5').",
+        "keys": [
+            {"env": "OLLAMA_API_BASE", "label": "Ollama server URL",
+             "default": "http://localhost:11434", "secret": False},
+        ],
+    },
+    {
+        "name":          "OpenAI-compatible (Ollama Cloud, Groq, Together, ...)",
+        "default_model": "openai_compat/{model}",
+        "model_label":   "Model name (as the vendor advertises it)",
+        "model_help":    (
+            "Pass the exact model id from the vendor — e.g. 'qwen3-coder:480b-cloud' "
+            "(Ollama Cloud), 'llama-3.3-70b-versatile' (Groq), "
+            "'mistral-large-latest' (Mistral La Plateforme)."
+        ),
+        "keys": [
+            # Vendor-dependent; deliberately no `url` here so the wizard
+            # doesn't render a misleading single hyperlink. The help_hint
+            # on the next key lists vendor dashboards.
+            {"env": "OPENAI_COMPAT_API_KEY",
+             "label": "API key (from your vendor's dashboard)"},
+            {"env": "OPENAI_COMPAT_API_BASE", "label": "OpenAI-compatible base URL",
+             "help": (
+                 "Examples: https://api.groq.com/openai/v1 (Groq), "
+                 "https://api.together.xyz/v1 (Together AI), "
+                 "https://api.mistral.ai/v1 (Mistral La Plateforme), "
+                 "https://openrouter.ai/api/v1 (OpenRouter). "
+                 "For Ollama Cloud, see https://docs.ollama.com for the current endpoint."
+             ),
+             "secret": False},
+        ],
     },
 ]
 
@@ -90,7 +171,11 @@ ADD_ONS = [
             {"env": "ANTHROPIC_API_KEY", "label": "Anthropic API key",
              "url": "https://console.anthropic.com/settings/keys"},
         ],
-        "exclude_for": ["Anthropic"],
+        # Skip the Anthropic add-on prompt for users already on a provider
+        # that hosts Claude — direct Anthropic API or Azure AI Foundry's
+        # Claude catalog. The slides agent's auto-upgrade still works since
+        # the credentials it reads belong to the chosen route.
+        "exclude_for": ["Anthropic", "Azure AI Foundry"],
     },
     {
         "id":          "composio",
@@ -193,6 +278,35 @@ def _ask_secret(label: str, url: str) -> str:
     return getpass.getpass(f"  {label}: ").strip()
 
 
+def _ask_text(label: str, default: str = "", help_hint: str = "") -> str:
+    if help_hint:
+        console.print(f"  [dim]{help_hint}[/dim]")
+    if _HAS_QUESTIONARY:
+        val = questionary.text(f"  {label}: ", default=default, style=_QSTYLE).ask()
+        return (val or "").strip() or default
+    suffix = f" [{default}]" if default else ""
+    raw = input(f"  {label}{suffix}: ").strip()
+    return raw or default
+
+
+def _ask_provider_key(spec: dict, existing_value: str) -> str:
+    """Ask for one provider env value, dispatching on `secret` flag.
+
+    secret=True (default) → password prompt + URL hint.
+    secret=False → plaintext prompt + optional help hint + default fallback.
+    """
+    is_secret = spec.get("secret", True)
+    if is_secret:
+        if spec.get("url"):
+            console.print(f"  [dim]Get yours at[/dim] [link={spec['url']}]{spec['url']}[/link]")
+        if _HAS_QUESTIONARY:
+            val = questionary.password(f"  {spec['label']}: ", style=_QSTYLE).ask()
+            return (val or "").strip() or existing_value
+        return getpass.getpass(f"  {spec['label']}: ").strip() or existing_value
+    default = existing_value or spec.get("default", "")
+    return _ask_text(spec["label"], default=default, help_hint=spec.get("help", ""))
+
+
 def _ask_confirm(message: str, default: bool = True) -> bool:
     if _HAS_QUESTIONARY:
         return questionary.confirm(message, default=default, style=_QSTYLE).ask()
@@ -232,23 +346,47 @@ def run_onboarding() -> None:
     ]
     provider = _ask_select("Choose your primary AI provider:", provider_choices)
 
-    # ── Step 2: API key ───────────────────────────────────────────────────────
-    _step(2, "API Key")
+    # ── Step 2: provider credentials ─────────────────────────────────────────
+    _step(2, "Provider Credentials")
 
-    existing_key = existing.get(provider["env_key"], "")
-    if existing_key:
-        console.print(f"  [dim]{provider['env_key']} is already configured.[/dim]")
-        if _ask_confirm("  Update it?", default=False):
-            key = _ask_secret(f"{provider['name']} API key", provider["url"])
-            updates[provider["env_key"]] = key or existing_key
-        else:
-            updates[provider["env_key"]] = existing_key
+    for key_spec in provider["keys"]:
+        env_name = key_spec["env"]
+        existing_val = existing.get(env_name, "")
+        is_secret = key_spec.get("secret", True)
+
+        if existing_val:
+            display = "***" if is_secret else existing_val
+            console.print(f"  [dim]{env_name} is already configured ({display}).[/dim]")
+            if not _ask_confirm("  Update it?", default=False):
+                updates[env_name] = existing_val
+                continue
+
+        new_val = _ask_provider_key(key_spec, existing_val)
+        if new_val:
+            updates[env_name] = new_val
+        elif existing_val:
+            updates[env_name] = existing_val
+
+    # Build DEFAULT_MODEL — providers with `{model}` template prompt for the name.
+    if "{model}" in provider["default_model"]:
+        existing_model = existing.get("DEFAULT_MODEL", "")
+        existing_suffix = ""
+        if existing_model and "/" in existing_model:
+            existing_suffix = existing_model.rsplit("/", 1)[-1]
+        # Loop until the user enters something — empty entry would leave
+        # DEFAULT_MODEL unset and produce a confusing summary table.
+        while True:
+            model_name = _ask_text(
+                provider.get("model_label", "Model name"),
+                default=existing_suffix,
+                help_hint=provider.get("model_help", ""),
+            )
+            if model_name:
+                updates["DEFAULT_MODEL"] = provider["default_model"].replace("{model}", model_name)
+                break
+            console.print("  [red]A model name is required.[/red]")
     else:
-        key = _ask_secret(f"{provider['name']} API key", provider["url"])
-        if key:
-            updates[provider["env_key"]] = key
-
-    updates["DEFAULT_MODEL"]       = provider["default_model"]
+        updates["DEFAULT_MODEL"] = provider["default_model"]
 
     # ── Step 3: add-ons ───────────────────────────────────────────────────────
     _step(3, "Add-ons  [dim](optional)[/dim]")
@@ -300,7 +438,10 @@ def run_onboarding() -> None:
     table.add_column(style="dim", no_wrap=True)
     table.add_column()
     table.add_row("Provider", f"[cyan]{provider['name']}[/cyan]")
-    table.add_row("Model",    f"[cyan]{provider['default_model']}[/cyan]")
+    # Show the resolved DEFAULT_MODEL (with {model} substituted for templated
+    # providers like azure_ai/{model}), not the raw template.
+    resolved_model = updates.get("DEFAULT_MODEL", provider["default_model"])
+    table.add_row("Model",    f"[cyan]{resolved_model}[/cyan]")
     table.add_row(".env",     f"[cyan]{ENV_PATH}[/cyan]")
     saved = [k for k, v in updates.items() if v and not k.startswith("DEFAULT_")]
     if saved:

--- a/orchestrator/instructions.md
+++ b/orchestrator/instructions.md
@@ -88,3 +88,17 @@ In this mode, transfer control early to the best specialist.
 # Agent-to-agent transfer
 - When one specialist agent needs to transfer user to a different one, use the `transfer` tool. You can use multiple transfers in a row if needed. Do not try to use `SendMessage` during agent-to-agent transfer and do not try to collect requirements for the task - this will be handled by the specialist agent.
 - Remember **you are a routing agent** - you are not responsible for data collection. Do not ask user for extra info, you only route user to an appropriate agent.
+
+# Administrative carve-out: provider switching
+
+When the user asks to change the LLM provider — phrases like "switch to ollama", "use Azure", "use Claude", "switch provider", or a literal `/switch-provider <args>` — call the `SwitchProvider` tool **directly**. This is the only task you handle yourself; it's an administrative concern, not a specialist task.
+
+Pass:
+- `provider`: one of `openai`, `anthropic`, `google`, `azure`, `azure_ai`, `ollama`, `openai_compat`
+- `model`: the model identifier (deployment name for `azure`, catalog model for `azure_ai`, locally-pulled model for `ollama`, vendor-advertised id for `openai_compat`)
+
+`openai_compat` is the generic route for any OpenAI-compatible endpoint (Ollama Cloud, Groq, Together AI, Mistral La Plateforme, OpenRouter, vLLM-based servers). It uses dedicated `OPENAI_COMPAT_API_KEY` / `OPENAI_COMPAT_API_BASE` env vars, so a real `OPENAI_API_KEY` set elsewhere is left intact.
+
+After the tool returns, tell the user to exit the TUI (`/quit` or Ctrl-C) — OpenSwarm will automatically restart with the new provider.
+
+If the tool reports missing credentials, tell the user to run `python onboard.py` to register them, then retry.

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -3,6 +3,7 @@ from openai.types.shared import Reasoning
 from dotenv import load_dotenv
 
 from config import get_default_model, is_openai_provider
+from orchestrator.tools import SwitchProvider
 
 load_dotenv()
 
@@ -19,6 +20,7 @@ def create_orchestrator() -> Agent:
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="medium", summary="auto") if is_openai_provider() else None,
         ),
+        tools=[SwitchProvider],
         conversation_starters=[
             "What can this agency do?",
             "Build a full launch package: research, slides, docs, and creative assets.",

--- a/orchestrator/tools/SwitchProvider.py
+++ b/orchestrator/tools/SwitchProvider.py
@@ -1,0 +1,185 @@
+"""Switch the agency's LLM provider at runtime.
+
+Writes DEFAULT_MODEL atomically to .env and signals run_utils.main() to
+recreate the agency on the next TUI loop iteration. The user must exit the
+TUI (`/quit` or Ctrl-C) for the switch to take effect — restart is automatic
+from there.
+
+Lives under orchestrator/tools/ rather than shared_tools/ because it
+deliberately sits outside the orchestrator's "router only" contract — see
+orchestrator/instructions.md for the documented carve-out. Specialist agents
+should never have access to this tool.
+
+NOTE: Provider switching only takes effect when running through
+run_utils.main() (i.e. `python swarm.py` or the npm CLI). The FastAPI server
+in server.py does not re-read DEFAULT_MODEL at runtime — switching from an
+API client will appear to succeed but is a no-op for that surface.
+
+Pre-existing provider credentials in .env are reused. To register new
+credentials, run `python onboard.py`.
+"""
+
+import os
+import re
+import urllib.parse
+from pathlib import Path
+
+from agency_swarm.tools import BaseTool
+from dotenv import dotenv_values, set_key
+from pydantic import Field
+
+from config import PROVIDER_REGISTRY
+
+ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
+SWITCH_FLAG_VAR = "OPENSWARM_SWITCH_FLAG"
+
+# Allowlist for the user-supplied `model` field. Must start with a
+# letter/digit (blocks `../...`, `.evil`, `/abs`); body allows the chars
+# real model names use (dot, colon, dash, slash, underscore). Blocks
+# newline injection into .env and shell metacharacters.
+_SAFE_MODEL = re.compile(r"^[A-Za-z0-9][\w.:\-/]*$")
+
+
+def _validate_openai_compat_base(url: str) -> str | None:
+    """Return None when url is safe, else an error message.
+
+    Defends against SSRF via attacker-controlled OPENAI_COMPAT_API_BASE: a
+    prompt-injection chain that pre-positions the base URL would otherwise
+    redirect all subsequent LLM traffic (with bearer tokens and conversation
+    history) to an attacker server. Restrict to https:// with a real hostname.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return "OPENAI_COMPAT_API_BASE is not a parseable URL."
+    if parsed.scheme != "https":
+        return f"OPENAI_COMPAT_API_BASE must use https:// (got '{parsed.scheme}://')."
+    if not parsed.hostname:
+        return "OPENAI_COMPAT_API_BASE has no hostname."
+    return None
+
+
+class SwitchProvider(BaseTool):
+    """
+    Switch the agency's LLM provider. Updates DEFAULT_MODEL in .env and signals
+    the TUI loop to rebuild the agency on next restart.
+
+    Use when the user says "switch to ollama", "use Azure", "use Claude",
+    "switch provider", or types `/switch-provider`. Pre-existing credentials
+    are reused. If credentials for the target provider are missing, returns a
+    clear instruction to run `python onboard.py`.
+
+    Provider slugs:
+      - openai          OpenAI API (gpt-5.2, o3, etc.)
+      - anthropic       Anthropic Claude via LiteLLM
+      - google          Google Gemini via LiteLLM
+      - azure           Azure OpenAI Service (your own gpt-* deployment)
+      - azure_ai        Azure AI Foundry catalog (Claude on Azure, Llama,
+                        Mistral, DeepSeek, ...)
+      - ollama          Local Ollama server
+      - openai_compat   Any OpenAI-compatible endpoint (Ollama Cloud, Groq,
+                        Together AI, Mistral La Plateforme, OpenRouter, vLLM)
+    """
+
+    provider: str = Field(
+        ...,
+        description=(
+            "Provider slug: openai, anthropic, google, azure, azure_ai, ollama, "
+            "or openai_compat."
+        ),
+    )
+    model: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Model identifier. openai: 'gpt-5.2'. anthropic: 'claude-sonnet-4-6'. "
+            "google: 'gemini-3-flash'. azure: deployment name. azure_ai: catalog "
+            "model (e.g. 'claude-opus-4-1'). ollama: locally-pulled model "
+            "(e.g. 'llama3.1'). openai_compat: vendor-advertised model id "
+            "(e.g. 'qwen3-coder:480b-cloud')."
+        ),
+    )
+
+    def run(self) -> str:
+        slug = self.provider.strip().lower()
+        if slug not in PROVIDER_REGISTRY:
+            return (
+                f"Unknown provider '{self.provider}'. Supported: "
+                f"{', '.join(PROVIDER_REGISTRY)}."
+            )
+
+        # Defense against attacker-controlled model strings (path traversal,
+        # newline injection, shell metacharacters).
+        if not _SAFE_MODEL.match(self.model):
+            return (
+                f"Invalid model identifier '{self.model}'. Allowed characters: "
+                "letters, digits, '.', ':', '-', '/', '_'."
+            )
+
+        prefix = PROVIDER_REGISTRY[slug]["prefix"]
+        required_env = PROVIDER_REGISTRY[slug]["required_env"]
+
+        # Read .env once; merge with process env so users who export keys
+        # in the shell aren't forced to write them to disk first.
+        on_disk = dotenv_values(str(ENV_PATH)) if ENV_PATH.exists() else {}
+        merged = {**on_disk, **{k: os.environ[k] for k in required_env if os.environ.get(k)}}
+        missing = [k for k in required_env if not merged.get(k)]
+        if missing:
+            return (
+                f"Cannot switch to {slug}: missing credentials {missing}.\n"
+                "Run `python onboard.py` to register them, then retry."
+            )
+
+        if slug == "openai_compat":
+            err = _validate_openai_compat_base(merged.get("OPENAI_COMPAT_API_BASE", ""))
+            if err:
+                return f"Refusing switch: {err}"
+
+        new_default_model = f"{prefix}{self.model}"
+
+        # Touch the restart flag BEFORE rewriting .env. Reasoning:
+        #
+        # If we wrote .env first and were killed between the write and the
+        # flag touch, the user would see "Provider switched" (already
+        # returned), .env would carry the new model, but the TUI loop in
+        # run_utils.main() would never pick it up — silent half-state.
+        #
+        # Touching the flag first means: if .env write fails afterward, the
+        # next loop iteration just re-reads the unchanged .env (one extra
+        # restart, no harm). If .env write succeeds, the flag is already in
+        # place. Order matters here.
+        flag_path = os.environ.get(SWITCH_FLAG_VAR)
+        if not flag_path:
+            return (
+                "Cannot switch — no restart signal available. This tool only "
+                "works when running through the OpenSwarm TUI loop "
+                "(`python swarm.py` or the npm CLI), not the FastAPI server."
+            )
+        try:
+            Path(flag_path).touch()
+        except OSError as exc:
+            return f"Refusing switch: could not write restart flag ({exc})."
+
+        # set_key on a temp copy + os.replace gives us atomic .env replacement
+        # on POSIX, so a concurrent reader can't see a half-written file.
+        # We deliberately rewrite the *whole* file via the temp rather than
+        # set_key-ing the live .env, since python-dotenv's set_key is not
+        # crash-safe on its own.
+        if not ENV_PATH.exists():
+            ENV_PATH.write_text("", encoding="utf-8")
+        tmp_path = ENV_PATH.with_suffix(ENV_PATH.suffix + ".tmp")
+        try:
+            tmp_path.write_text(ENV_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+            set_key(str(tmp_path), "DEFAULT_MODEL", new_default_model)
+            os.replace(str(tmp_path), str(ENV_PATH))
+        finally:
+            # Clean up the temp on the failure path; on success os.replace
+            # already consumed it (Path.exists() returns False then).
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+
+        return (
+            f"Provider switched to {slug} (DEFAULT_MODEL={new_default_model}).\n"
+            "Exit the TUI (`/quit` or Ctrl-C) and OpenSwarm will automatically "
+            "restart with the new provider."
+        )

--- a/orchestrator/tools/__init__.py
+++ b/orchestrator/tools/__init__.py
@@ -1,0 +1,11 @@
+"""Tools registered exclusively on the orchestrator.
+
+Lives separate from `shared_tools/` so it cannot be imported via wildcard
+or accidentally given to a specialist agent. Anything here breaks the
+orchestrator's strict "router only" contract by design — see
+orchestrator/instructions.md for the documented carve-out.
+"""
+
+from orchestrator.tools.SwitchProvider import SwitchProvider
+
+__all__ = ["SwitchProvider"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,18 @@ dependencies = [
     "httpx",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
 [project.scripts]
 openswarm = "run_utils:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-q"
 
 [tool.setuptools]
 py-modules = ["agency", "swarm", "helpers", "config", "onboard", "server"]

--- a/run_utils.py
+++ b/run_utils.py
@@ -157,12 +157,15 @@ def _bootstrap() -> None:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+# Truly optional integrations beyond the primary provider — used for the
+# startup summary. Provider keys (OpenAI, Anthropic, Google, Azure, Ollama,
+# OpenAI-compatible) are no longer listed here since they're now first-class
+# choices rather than add-ons; selecting Azure as the primary shouldn't make
+# the user feel they're missing Anthropic.
 _OPTIONAL_INTEGRATIONS = [
     ("Composio (10,000+ external integrations)", ["COMPOSIO_API_KEY", "COMPOSIO_USER_ID"]),
-    ("Anthropic / Claude models", ["ANTHROPIC_API_KEY"]),
     ("Search", ["SEARCH_API_KEY"]),
     ("Fal.ai (video & audio generation)", ["FAL_KEY"]),
-    ("Google AI / Gemini", ["GOOGLE_API_KEY"]),
     ("Pexels (stock images)", ["PEXELS_API_KEY"]),
     ("Pixabay (stock images)", ["PIXABAY_API_KEY"]),
     ("Unsplash (stock images)", ["UNSPLASH_ACCESS_KEY"]),
@@ -253,9 +256,16 @@ def main() -> None:
 
     from swarm import create_agency
 
-    onboard_flag = Path(tempfile.gettempdir()) / "_openswarm_onboard.flag"
+    # User-scoped flag directory so a co-tenant on /tmp can't force a
+    # spurious restart by touching our flag files (Linux/macOS DoS vector).
+    flag_dir = Path(tempfile.gettempdir()) / f"openswarm_{os.getuid() if hasattr(os, 'getuid') else 'user'}"
+    flag_dir.mkdir(mode=0o700, exist_ok=True)
+    onboard_flag = flag_dir / "_onboard.flag"
+    switch_flag = flag_dir / "_switch.flag"
     os.environ["OPENSWARM_ONBOARD_FLAG"] = str(onboard_flag)
+    os.environ["OPENSWARM_SWITCH_FLAG"] = str(switch_flag)
     onboard_flag.unlink(missing_ok=True)
+    switch_flag.unlink(missing_ok=True)
 
     while True:
         import logging
@@ -298,6 +308,18 @@ def main() -> None:
             from onboard import run_onboarding
             run_onboarding()
             load_dotenv(override=True)
+        elif switch_flag.exists():
+            switch_flag.unlink(missing_ok=True)
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+            logging.disable(logging.NOTSET)
+            print("\nApplying provider switch — restarting agency with new DEFAULT_MODEL…")
+            load_dotenv(override=True)
+            # Sanity check — refuse to loop into create_agency() if the
+            # write somehow ended up empty (disk full, race).
+            if not os.getenv("DEFAULT_MODEL", "").strip():
+                print("ERROR: DEFAULT_MODEL is empty after switch. Check .env.")
+                break
         else:
             break
 

--- a/server.py
+++ b/server.py
@@ -1,4 +1,11 @@
 # FastAPI entry point — run with: python server.py
+#
+# NOTE: This entry point creates the agency once at startup and serves it
+# for the lifetime of the process. The SwitchProvider tool registered on
+# the orchestrator writes to .env and signals a restart, but only the TUI
+# loop in run_utils.main() reads that signal — the FastAPI surface does
+# not. Provider switches issued through this server appear to succeed but
+# stay pinned to the original DEFAULT_MODEL until the server is restarted.
 
 import logging
 from dotenv import load_dotenv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+"""Test scaffolding.
+
+These tests target configuration and tool-routing logic that lives in
+config.py, orchestrator/tools/SwitchProvider.py, and onboard.py. The
+production code imports `agency_swarm` (and the wider OpenAI Agents SDK
+ecosystem), but the logic under test does not actually need any of that —
+SwitchProvider only needs `BaseTool` as a Pydantic-shaped base class, and
+config._resolve only needs `LitellmModel` as a constructable callable.
+
+Stubbing those two surfaces here keeps the test suite runnable from a bare
+Python install (`pip install pytest python-dotenv pydantic`) without
+requiring the multi-hundred-megabyte agency-swarm + openai-agents-sdk +
+LiteLLM dependency chain.
+"""
+
+import sys
+import types
+
+from pydantic import BaseModel
+
+
+def _install_agency_swarm_stubs() -> None:
+    """Register fake `agency_swarm` and supporting modules in sys.modules.
+
+    Production code does:
+        from agency_swarm.tools import BaseTool
+        from agency_swarm import LitellmModel, Agent, ModelSettings
+        from openai.types.shared import Reasoning
+
+    The orchestrator package imports Agent/ModelSettings/Reasoning at module
+    load time (via `from .orchestrator import create_orchestrator` in
+    orchestrator/__init__.py). Importing `orchestrator.tools.SwitchProvider`
+    therefore triggers that chain. Stub all of them — none are exercised by
+    the test logic; they only need to be importable.
+    """
+    pkg = sys.modules.get("agency_swarm")
+    if pkg is not None and getattr(pkg, "_openswarm_test_stub", False):
+        return  # already installed
+
+    pkg = types.ModuleType("agency_swarm")
+    pkg._openswarm_test_stub = True  # type: ignore[attr-defined]
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class _ModelSettings:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class _LitellmModel:
+        """Records constructor kwargs as attributes for test assertions."""
+
+        def __init__(self, model, api_key=None, base_url=None, **kwargs):
+            self.model = model
+            self.api_key = api_key
+            self.base_url = base_url
+            self.kwargs = kwargs
+
+    pkg.Agent = _Agent  # type: ignore[attr-defined]
+    pkg.ModelSettings = _ModelSettings  # type: ignore[attr-defined]
+    pkg.LitellmModel = _LitellmModel  # type: ignore[attr-defined]
+
+    tools = types.ModuleType("agency_swarm.tools")
+
+    class _BaseTool(BaseModel):
+        def run(self):
+            raise NotImplementedError
+
+    tools.BaseTool = _BaseTool  # type: ignore[attr-defined]
+
+    sys.modules["agency_swarm"] = pkg
+    sys.modules["agency_swarm.tools"] = tools
+
+    # openai.types.shared.Reasoning — orchestrator imports this directly.
+    # Real openai package may already be installed, so only stub the path
+    # if it doesn't resolve.
+    try:
+        from openai.types.shared import Reasoning  # noqa: F401
+    except (ImportError, ModuleNotFoundError):
+        openai_pkg = sys.modules.get("openai") or types.ModuleType("openai")
+        openai_types = sys.modules.get("openai.types") or types.ModuleType("openai.types")
+        openai_shared = types.ModuleType("openai.types.shared")
+
+        class _Reasoning:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        openai_shared.Reasoning = _Reasoning  # type: ignore[attr-defined]
+        sys.modules["openai"] = openai_pkg
+        sys.modules["openai.types"] = openai_types
+        sys.modules["openai.types.shared"] = openai_shared
+
+
+_install_agency_swarm_stubs()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,134 @@
+"""config.py — model resolution and provider classification."""
+
+import pytest
+
+import config
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in (
+        "DEFAULT_MODEL",
+        "OPENAI_COMPAT_API_KEY", "OPENAI_COMPAT_API_BASE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_provider_registry_has_seven_slugs():
+    assert set(config.PROVIDER_REGISTRY) == {
+        "openai", "anthropic", "google",
+        "azure", "azure_ai", "ollama", "openai_compat",
+    }
+
+
+@pytest.mark.parametrize(
+    "model,expected_slug",
+    [
+        ("gpt-5.2",                                  "openai"),
+        ("o3",                                       "openai"),
+        ("litellm/claude-sonnet-4-6",                "anthropic"),
+        ("litellm/gemini/gemini-3-flash",            "google"),
+        ("azure/my-deployment",                       "azure"),
+        # azure_ai/ must match before azure/ would (longest prefix wins).
+        ("azure_ai/claude-opus-4-1",                 "azure_ai"),
+        ("ollama_chat/llama3.1",                     "ollama"),
+        ("openai_compat/qwen3-coder:480b-cloud",     "openai_compat"),
+    ],
+)
+def test_get_active_provider_classifies_all_prefixes(model, expected_slug, monkeypatch):
+    monkeypatch.setenv("DEFAULT_MODEL", model)
+    assert config.get_active_provider() == expected_slug
+
+
+def test_resolve_openai_compat_unwraps_correctly(monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "https://api.groq.com/openai/v1")
+    monkeypatch.setenv("DEFAULT_MODEL", "openai_compat/llama-3.3-70b-versatile")
+
+    result = config.get_default_model()
+    # The conftest stub records constructor kwargs as attributes.
+    assert result.model == "openai/llama-3.3-70b-versatile"
+    assert result.api_key == "sk-test"
+    assert result.base_url == "https://api.groq.com/openai/v1"
+
+
+def test_resolve_openai_compat_raises_on_missing_base(monkeypatch):
+    """Better to fail loudly at startup than give a cryptic LiteLLM error
+    on the first model call."""
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_COMPAT_API_BASE", raising=False)
+    monkeypatch.setenv("DEFAULT_MODEL", "openai_compat/foo")
+
+    with pytest.raises(RuntimeError, match="OPENAI_COMPAT_API_BASE"):
+        config.get_default_model()
+
+
+def test_bare_openai_model_passes_through_unchanged(monkeypatch):
+    monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.2")
+    assert config.get_default_model() == "gpt-5.2"
+
+
+def test_is_openai_provider_only_true_for_bare_models(monkeypatch):
+    monkeypatch.setenv("DEFAULT_MODEL", "gpt-5.2")
+    assert config.is_openai_provider() is True
+
+    monkeypatch.setenv("DEFAULT_MODEL", "azure/anything")
+    assert config.is_openai_provider() is False
+
+    monkeypatch.setenv("DEFAULT_MODEL", "openai_compat/anything")
+    assert config.is_openai_provider() is False
+
+
+def test_resolve_threads_ollama_api_base(monkeypatch):
+    """Ollama users who set OLLAMA_API_BASE in .env expect the URL to
+    actually be used. Don't rely on LiteLLM's env-var fallback —
+    pass it explicitly."""
+    monkeypatch.setenv("DEFAULT_MODEL", "ollama_chat/llama3.1")
+    monkeypatch.setenv("OLLAMA_API_BASE", "http://my-ollama-server:11434")
+    result = config.get_default_model()
+    assert result.model == "ollama_chat/llama3.1"
+    assert result.base_url == "http://my-ollama-server:11434"
+
+
+def test_resolve_typeerror_propagates(monkeypatch):
+    """A misconfigured kwarg in LitellmModel construction should surface
+    immediately, not silently degrade to a bare string."""
+    import sys
+
+    class _BrokenLitellmModel:
+        def __init__(self, *args, **kwargs):
+            raise TypeError("unsupported kwarg in LitellmModel signature")
+
+    monkeypatch.setattr(sys.modules["agency_swarm"], "LitellmModel", _BrokenLitellmModel)
+    monkeypatch.setenv("DEFAULT_MODEL", "litellm/claude-sonnet-4-6")
+
+    with pytest.raises(TypeError, match="unsupported kwarg"):
+        config.get_default_model()
+
+
+def test_resolve_importerror_degrades_gracefully(monkeypatch):
+    """When agency-swarm is genuinely missing, _resolve should return the
+    original model string rather than crash. (Different from TypeError,
+    which signals a programming error and must propagate.)"""
+    import sys
+
+    saved = sys.modules.pop("agency_swarm", None)
+    try:
+        # Block re-import attempts within this test
+        monkeypatch.setitem(sys.modules, "agency_swarm", None)
+        monkeypatch.setenv("DEFAULT_MODEL", "litellm/claude-sonnet-4-6")
+        result = config.get_default_model()
+        # ImportError swallowed; we get the original model string back
+        # (unwrapped via the litellm/ strip the function does upstream).
+        assert result == "litellm/claude-sonnet-4-6"
+    finally:
+        if saved is not None:
+            sys.modules["agency_swarm"] = saved
+
+
+def test_get_active_provider_unknown_for_unrecognized_litellm_models(monkeypatch):
+    """A user with a custom litellm/<vendor>/<model> string should get
+    'unknown' rather than the misleading 'litellm' slug that isn't in
+    the registry."""
+    monkeypatch.setenv("DEFAULT_MODEL", "litellm/cohere/command-r-plus")
+    assert config.get_active_provider() == "unknown"

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -1,0 +1,49 @@
+"""onboard.py — wizard data shape contract.
+
+The wizard iterates `provider["keys"]` and substitutes `{model}` into
+`provider["default_model"]`. A malformed entry crashes at runtime with
+KeyError. These tests catch that before the wizard ever runs.
+"""
+
+from onboard import PROVIDERS, ADD_ONS
+
+
+def test_every_provider_has_required_top_level_fields():
+    for p in PROVIDERS:
+        missing = {"name", "default_model", "keys"} - p.keys()
+        assert not missing, f"Provider {p.get('name')!r} missing fields: {missing}"
+
+
+def test_every_key_spec_has_env_and_label():
+    for p in PROVIDERS:
+        for spec in p["keys"]:
+            assert "env" in spec, f"{p['name']} key missing 'env': {spec}"
+            assert "label" in spec, f"{p['name']} key missing 'label': {spec}"
+
+
+def test_templated_providers_have_model_label():
+    """If default_model contains '{model}', the wizard prompts for it —
+    so the spec must declare what label to show on that prompt."""
+    for p in PROVIDERS:
+        if "{model}" in p["default_model"]:
+            assert "model_label" in p, (
+                f"Provider {p['name']!r} uses {{model}} template but has "
+                "no model_label — the wizard would crash on this entry."
+            )
+
+
+def test_anthropic_addon_excludes_azure_ai_foundry():
+    """Picking azure_ai with a Claude model already covers Anthropic — the
+    wizard should not prompt for a separate ANTHROPIC_API_KEY in that flow."""
+    addon = next(a for a in ADD_ONS if a["id"] == "anthropic")
+    assert "Azure AI Foundry" in addon["exclude_for"]
+    assert "Anthropic" in addon["exclude_for"]
+
+
+def test_openai_compat_key_has_no_url_field():
+    """The key spec deliberately omits `url` since the relevant URL
+    depends on which vendor (Ollama Cloud vs Groq vs Together vs ...).
+    Rich would render any URL string here as a single misleading hyperlink."""
+    p = next(p for p in PROVIDERS if "OpenAI-compatible" in p["name"])
+    api_key_spec = next(k for k in p["keys"] if k["env"] == "OPENAI_COMPAT_API_KEY")
+    assert "url" not in api_key_spec

--- a/tests/test_switch_provider.py
+++ b/tests/test_switch_provider.py
@@ -1,0 +1,208 @@
+"""SwitchProvider — the runtime provider switch tool."""
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+from dotenv import dotenv_values
+from pydantic import ValidationError
+
+# Import the module explicitly to avoid the shadowing in
+# orchestrator/tools/__init__.py, which re-exports the SwitchProvider
+# *class* under the same dotted path as the submodule.
+sp_module = importlib.import_module("orchestrator.tools.SwitchProvider")
+SwitchProvider = sp_module.SwitchProvider
+
+
+@pytest.fixture
+def env_path(tmp_path, monkeypatch):
+    """Redirect the module-level ENV_PATH to a temp file."""
+    env = tmp_path / ".env"
+    env.write_text("", encoding="utf-8")
+    monkeypatch.setattr(sp_module, "ENV_PATH", env)
+    return env
+
+
+@pytest.fixture
+def flag_path(tmp_path, monkeypatch):
+    """Wire the restart flag to a temp path the test can inspect."""
+    flag = tmp_path / "switch.flag"
+    monkeypatch.setenv("OPENSWARM_SWITCH_FLAG", str(flag))
+    return flag
+
+
+@pytest.fixture(autouse=True)
+def clear_provider_env(monkeypatch):
+    """Strip provider keys from the test process so tests start clean."""
+    for var in (
+        "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY",
+        "AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION",
+        "AZURE_AI_API_KEY", "AZURE_AI_API_BASE",
+        "OPENAI_COMPAT_API_KEY", "OPENAI_COMPAT_API_BASE",
+        "OLLAMA_API_BASE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_unknown_provider_returns_supported_list(env_path, flag_path):
+    result = SwitchProvider(provider="bedrock", model="nova-pro").run()
+    assert "Unknown provider" in result
+    assert "openai_compat" in result  # the registry's full vocabulary surfaces
+
+
+def test_empty_model_rejected_by_pydantic(env_path):
+    # min_length=1 on the Field ensures the validation error surfaces
+    # before run() executes — no .env mutation can happen.
+    with pytest.raises(ValidationError):
+        SwitchProvider(provider="openai", model="")
+
+
+def test_model_field_blocks_newline_injection(env_path, flag_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    result = SwitchProvider(provider="openai", model="x\nMALICIOUS=1").run()
+    assert "Invalid model" in result
+    # .env must not have been written
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") in (None, "")
+
+
+def test_openai_compat_rejects_http_url(env_path, flag_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk-evil")
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "http://attacker.example.com/v1")
+    result = SwitchProvider(
+        provider="openai_compat", model="qwen3-coder:480b-cloud"
+    ).run()
+    assert "must use https" in result
+    # .env must not have been written
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") in (None, "")
+
+
+def test_openai_compat_rejects_no_hostname(env_path, flag_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk")
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "https:///")
+    result = SwitchProvider(
+        provider="openai_compat", model="qwen3-coder"
+    ).run()
+    assert "no hostname" in result.lower()
+
+
+def test_missing_credentials_surfaces_env_var_names(env_path, flag_path):
+    result = SwitchProvider(provider="azure", model="my-deployment").run()
+    assert "missing credentials" in result
+    # All three Azure vars should be named so the user knows what to set.
+    for var in ("AZURE_API_KEY", "AZURE_API_BASE", "AZURE_API_VERSION"):
+        assert var in result
+
+
+def test_successful_switch_writes_env_and_touches_flag(
+    env_path, flag_path, monkeypatch
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    result = SwitchProvider(provider="openai", model="gpt-5.2").run()
+    assert "switched" in result.lower()
+    assert flag_path.exists()
+    # dotenv_values strips quotes — round-trip should preserve the slash form.
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") == "gpt-5.2"
+
+
+def test_openai_compat_writes_correct_default_model(
+    env_path, flag_path, monkeypatch
+):
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk")
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "https://api.groq.com/openai/v1")
+    result = SwitchProvider(
+        provider="openai_compat", model="llama-3.3-70b-versatile"
+    ).run()
+    assert "switched" in result.lower()
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") == (
+        "openai_compat/llama-3.3-70b-versatile"
+    )
+
+
+def test_atomic_write_leaves_no_tmp_file(env_path, flag_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    SwitchProvider(provider="openai", model="gpt-5.2").run()
+    tmp = env_path.with_suffix(env_path.suffix + ".tmp")
+    assert not tmp.exists(), ".env.tmp left over after atomic write"
+
+
+def test_no_flag_env_var_refuses_switch(env_path, monkeypatch):
+    """When OPENSWARM_SWITCH_FLAG isn't set the tool must refuse outright,
+    not write .env and pretend it succeeded — flag is touched BEFORE the
+    .env mutation by design."""
+    monkeypatch.delenv("OPENSWARM_SWITCH_FLAG", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    result = SwitchProvider(provider="openai", model="gpt-5.2").run()
+    assert "Cannot switch" in result
+    # .env must NOT have been mutated — the new ordering enforces this.
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") in (None, "")
+
+
+def test_oserror_on_flag_touch_aborts_switch(env_path, flag_path, monkeypatch):
+    """If the flag can't be written (disk full, permissions), the tool
+    must refuse before touching .env."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    def boom(self):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(Path, "touch", boom)
+    result = SwitchProvider(provider="openai", model="gpt-5.2").run()
+    assert "Refusing switch" in result
+    assert "disk full" in result
+    # .env must NOT have been mutated.
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") in (None, "")
+
+
+def test_atomic_write_recovers_when_set_key_fails(env_path, flag_path, monkeypatch):
+    """If set_key blows up mid-write, the original .env stays intact and
+    no .env.tmp is left over."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    env_path.write_text("EXISTING_KEY=preserved\n", encoding="utf-8")
+
+    def boom(*a, **kw):
+        raise RuntimeError("simulated set_key failure")
+
+    monkeypatch.setattr(sp_module, "set_key", boom)
+
+    with pytest.raises(RuntimeError, match="simulated set_key failure"):
+        SwitchProvider(provider="openai", model="gpt-5.2").run()
+
+    # Original .env unchanged
+    contents = env_path.read_text(encoding="utf-8")
+    assert "EXISTING_KEY=preserved" in contents
+    # No .env.tmp leftover
+    assert not env_path.with_suffix(env_path.suffix + ".tmp").exists()
+
+
+def test_openai_compat_works_without_api_key(env_path, flag_path, monkeypatch):
+    """Local vLLM and some OpenRouter setups are keyless — the registry
+    only requires OPENAI_COMPAT_API_BASE, not the key."""
+    monkeypatch.delenv("OPENAI_COMPAT_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "https://my-vllm.local/v1")
+    result = SwitchProvider(provider="openai_compat", model="qwen3-coder").run()
+    assert "switched" in result.lower()
+    assert dotenv_values(str(env_path)).get("DEFAULT_MODEL") == (
+        "openai_compat/qwen3-coder"
+    )
+
+
+def test_dotenv_round_trip_preserves_slash_models(env_path, flag_path, monkeypatch):
+    """python-dotenv quotes some values when writing — verify load_dotenv
+    and dotenv_values both unquote consistently. A regression here would
+    silently break the credential check on the next switch."""
+    from dotenv import load_dotenv
+
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "sk")
+    monkeypatch.setenv("OPENAI_COMPAT_API_BASE", "https://api.groq.com/openai/v1")
+    SwitchProvider(
+        provider="openai_compat", model="qwen3-coder:480b-cloud"
+    ).run()
+
+    # Both readers should return the unquoted form.
+    via_values = dotenv_values(str(env_path))["DEFAULT_MODEL"]
+    monkeypatch.delenv("DEFAULT_MODEL", raising=False)
+    load_dotenv(str(env_path), override=True)
+    via_loadenv = os.environ["DEFAULT_MODEL"]
+
+    assert via_values == via_loadenv == "openai_compat/qwen3-coder:480b-cloud"


### PR DESCRIPTION
## Summary

Extends OpenSwarm's provider matrix from three (OpenAI / Anthropic / Google) to seven, plus a runtime provider switch reachable from the orchestrator.

## What's new

**Providers**
- **Azure OpenAI Service** — your own gpt-* deployment (`azure/<deployment>`).
- **Azure AI Foundry** — catalog of Anthropic Claude (Opus/Sonnet), Llama, Mistral, DeepSeek, etc. via `azure_ai/<model>`. For Anthropic models, the base URL ends with `/anthropic`.
- **Ollama (local)** — keyless, defaults to `http://localhost:11434`. `OLLAMA_API_BASE` is threaded explicitly.
- **OpenAI-compatible** — generic `openai_compat/<model>` route covering Ollama Cloud, Groq, Together AI, Mistral La Plateforme, OpenRouter, vLLM. Uses dedicated `OPENAI_COMPAT_*` env vars so a real `OPENAI_API_KEY` kept for fallback is never overwritten.

**Runtime switching**
- `SwitchProvider` tool registered exclusively on the orchestrator (lives under `orchestrator/tools/` rather than `shared_tools/` so specialists can't import it). Users say "switch to ollama llama3.1" or "switch to azure_ai claude-opus-4-1"; the tool validates credentials, writes `DEFAULT_MODEL` to `.env` atomically, and signals `run_utils.main()` to rebuild the agency on next TUI exit.
- The orchestrator's "router only" contract is preserved with one documented carve-out (provider switching is administrative, not a specialist task).
- The FastAPI server in `server.py` doesn't read the restart signal — switching from the API surface is a documented no-op.

**Architecture**
- Single source of truth: `config.PROVIDER_REGISTRY` maps slug → (prefix, required_env). Both the wizard and the SwitchProvider tool derive from this table — adding an 8th provider is one entry plus an optional UI entry in `onboard.PROVIDERS`.
- `get_active_provider()` uses longest-prefix-wins lookup so `azure_ai/` matches before `azure/` would.
- The `anthropic` prefix is `litellm/claude` (not `litellm/`) so `litellm/cohere/...` and other LiteLLM third-party models aren't misclassified as Anthropic.

## Hardening

- **SSRF defense**: SwitchProvider refuses any `openai_compat` switch where `OPENAI_COMPAT_API_BASE` isn't an `https://` URL with a real hostname. Closes the prompt-injection chain where an attacker pre-positions the base URL and induces a switch, redirecting all subsequent LLM traffic with bearer tokens and conversation history.
- **Input validation**: `model` field requires alphanumeric start + `[\w.:-/]`. Blocks newline injection into `.env`, shell metacharacters, and traversal-style ids.
- **Atomic `.env` write**: the restart flag is touched **before** the rewrite, so a crash in any window leaves recoverable state. The rewrite uses `set_key` on a temp copy then `os.replace`.
- `config._resolve()` raises `RuntimeError` when `openai_compat` is configured without the base URL, instead of constructing a `LitellmModel` with `None` credentials that would fail cryptically at first call.
- The `except` clause in `_resolve` catches only `ImportError`; `TypeError` propagates so misconfigured kwargs surface immediately rather than degrading to a bare model string.
- Restart flag files live in a user-scoped tempdir (mode 0o700) so a co-tenant on `/tmp` can't force a spurious restart.

## Tests

36 pytest cases cover provider validation, SSRF guard, input validation, atomic write recovery, missing-credential errors, prefix classification (incl. longest-prefix-wins for `azure_ai/` vs `azure/`), `openai_compat` unwrap to `openai/<model>`, `RuntimeError` on missing `API_BASE`, `ImportError` graceful degradation, `TypeError` propagation, dotenv quoting round-trips, OSError on flag touch refuses switch, and the wizard's `PROVIDERS` data shape contract.

Test scaffolding stubs `agency_swarm` and `openai.types.shared` in `sys.modules` so the suite runs from a bare Python install with just `pytest + python-dotenv + pydantic`.

```
$ pip install pytest && pytest
========================== 36 passed in 0.33s =============================
```

## Documentation

- `README.md` updated with the 7-provider list, runtime switch description, and an "Upgrading from an earlier version" note.
- `AGENTS.md` documents the `orchestrator/tools/` convention and the `PROVIDER_REGISTRY` contract.
- `orchestrator/instructions.md` documents the administrative carve-out.
- `.env.example` documents every new env var with vendor URL examples for `openai_compat` (Groq, Together, Mistral, OpenRouter; Ollama Cloud points at https://docs.ollama.com since the canonical endpoint can change).

## Test plan

- [x] All 36 unit tests pass on a bare Python install
- [x] Pre-PR review by independent code-review-expert and verifier agents (findings addressed)
- [ ] **Pending end-to-end verification with real keys**: Azure OpenAI deployment, Azure AI Foundry Claude, Ollama Cloud, Groq — these require accounts I don't have here. Happy to coordinate with anyone who has them.
- [x] Provider switch signal mechanism (flag + run_utils restart loop) verified manually with `OPENSWARM_SWITCH_FLAG` mocked

## Backwards compatibility

Nothing breaks. Bare `DEFAULT_MODEL=gpt-5.2` strings still route to OpenAI; `litellm/<model>` strings still route through LiteLLM. `onboard.PROVIDERS` shape changed from single `env_key` to `keys: [...]` (refactored to support multi-credential providers like Azure), but no external consumer of that dict was found in the repo. Existing `.env` files keep working.

## Notes for review

- **Private-IP SSRF guard**: deliberately permissive (allows `https://127.0.0.1/v1`) because OpenSwarm targets local development and self-hosted vLLM / Ollama Cloud / etc. are legitimate use cases. Open to changing this if you'd prefer a stricter default with an opt-in env var for local endpoints.
- **`server.py` blind spot**: documented rather than fixed. Adding a watchdog/reload mechanism for the FastAPI surface is a bigger change worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)