### PR TITLE
Fix Intel macOS release runner

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -111,7 +111,7 @@ jobs:
           - os: macos-latest
             platform: darwin
             arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             platform: darwin
             arch: x64
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the retired `macos-13` release build runner with GitHub's current Intel macOS runner label
- keep the darwin x64 release asset in the OpenSwarm prerelease workflow

## Evidence
- GitHub release workflow run 25754375753 is blocked only on the queued `macos-13` x64 job
- YAML parse passed for all workflows
- `git diff --check` passed
- final diff is one runner-label replacement