### PR TITLE
fix: build OpenSwarm TUI with product profile

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -141,7 +141,18 @@ jobs:
         working-directory: agentswarm-cli/packages/opencode
         env:
           OPENCODE_CHANNEL: latest
-          OPENCODE_VERSION: ${{ env.AGENTSWARM_CLI_VERSION }}
+          AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
+          AGENTSWARM_PRODUCT_COMMAND: openswarm
+          AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"
+          AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: "@vrsen/openswarm"
+          AGENTSWARM_PRODUCT_RELEASE_REPO: VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_DOCS_URL: https://github.com/VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_ISSUE_URL: https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml
+          AGENTSWARM_PRODUCT_MDNS_DOMAIN: openswarm.local
+          AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
+          AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py,agency.py
+          AGENTSWARM_PRODUCT_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: bun run script/build.ts --single --skip-install
 
       - name: Rename binary (Unix)

--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AGENTSWARM_CLI_VERSION: 1.4.32
+  AGENTSWARM_CLI_VERSION: 1.4.33
 
 jobs:
   prepare:
@@ -140,7 +140,7 @@ jobs:
       - name: Build binary
         working-directory: agentswarm-cli/packages/opencode
         env:
-          OPENCODE_CHANNEL: latest
+          OPENCODE_CHANNEL: ${{ needs.prepare.outputs.npm_tag }}
           AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
           AGENTSWARM_PRODUCT_COMMAND: openswarm
           AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
-          ref: v1.4.32
+          ref: v1.4.33
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:
@@ -31,13 +31,24 @@ jobs:
         shell: bash
         working-directory: agentswarm-cli
         env:
-          OPENCODE_CHANNEL: latest
-          OPENCODE_VERSION: 1.4.32
+          OPENCODE_CHANNEL: rc
+          AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
+          AGENTSWARM_PRODUCT_COMMAND: openswarm
+          AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"
+          AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: "@vrsen/openswarm"
+          AGENTSWARM_PRODUCT_RELEASE_REPO: VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_DOCS_URL: https://github.com/VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_ISSUE_URL: https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml
+          AGENTSWARM_PRODUCT_MDNS_DOMAIN: openswarm.local
+          AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
+          AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
+          AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py,agency.py
+          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.2
         run: |
           bun install
           cd packages/opencode
           bun run script/build.ts --single --skip-install
-          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.4.32"
+          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.2"
       - name: Test startup
         shell: bash
         run: |

--- a/bin/openswarm
+++ b/bin/openswarm
@@ -11,6 +11,20 @@ const path = require('path')
 const scriptPath = fs.realpathSync(__filename)
 const packageDir = path.dirname(path.dirname(scriptPath))
 const packageJson = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'))
+const downstreamEnv = {
+  AGENTSWARM_PRODUCT_DISPLAY_NAME: 'OpenSwarm',
+  AGENTSWARM_PRODUCT_COMMAND: 'openswarm',
+  AGENTSWARM_PRODUCT_PACKAGE_NAME: '@vrsen/openswarm',
+  AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: '@vrsen/openswarm',
+  AGENTSWARM_PRODUCT_RELEASE_REPO: 'VRSEN/OpenSwarm',
+  AGENTSWARM_PRODUCT_DOCS_URL: 'https://github.com/VRSEN/OpenSwarm',
+  AGENTSWARM_PRODUCT_ISSUE_URL: 'https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml',
+  AGENTSWARM_PRODUCT_MDNS_DOMAIN: 'openswarm.local',
+  AGENTSWARM_PRODUCT_STARTER_REPO: 'VRSEN/OpenSwarm',
+  AGENTSWARM_PRODUCT_STARTER_FOLDER: 'openswarm',
+  AGENTSWARM_PRODUCT_ENTRY_FILES: 'swarm.py,agency.py',
+  AGENTSWARM_PRODUCT_VERSION: packageJson.version,
+}
 
 function resolveAgentswarm(startDir) {
   let current = startDir
@@ -58,6 +72,7 @@ function validateBinary(binaryPath) {
     env: {
       ...process.env,
       AGENTSWARM_LAUNCHER: '0',
+      ...downstreamEnv,
     },
     encoding: 'utf8',
     timeout: 15000,
@@ -173,6 +188,7 @@ async function main() {
   const customBinary = await ensureCustomBinary()
   const env = {
     ...process.env,
+    ...downstreamEnv,
     AGENTSWARM_LAUNCHER: process.env.AGENTSWARM_LAUNCHER || '1',
     PYTHONUTF8: process.env.PYTHONUTF8 || '1',
     PYTHONIOENCODING: process.env.PYTHONIOENCODING || 'utf-8',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.1",
+    "version": "1.0.1-rc.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.1",
+            "version": "1.0.1-rc.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.32",
+                "@vrsen/agentswarm": "1.4.33",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -496,21 +496,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.32.tgz",
-            "integrity": "sha512-K2ojt56lThrQZIYtkCeHnShnIbnygwx8U79vftpZNMugYWyB36KvXIww7DsOJ9RzV4+gmWXX3MPlmAC8fSEcqA==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.33.tgz",
+            "integrity": "sha512-KEZ42I0o6XR9bwqpgvMF6Z1GwH7QvDsks64pNl2kP7zMu/E2EyQIFFvT2V6x1E7geEsM0GczKUt+pXYrJ/chyw==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.32"
+                "agentswarm-cli": "1.4.33"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.32.tgz",
-            "integrity": "sha512-UgPjM0JfAwawHbN26q/4/xI9fqDu3a4z6Rhs3iHsR7FbAtdyJ+UnAPYUJeG6U4MhfhjHgu4u5T3URNKRnjBugg==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.33.tgz",
+            "integrity": "sha512-luQIcapPhiwcIam5EjPd4kPgRgCidkhWZAbf1m2Oh04QgRzJR3KNEN44ZyKrh+d0CoJUmVoFi6FkvoFSVISZog==",
             "cpu": [
                 "arm64"
             ],
@@ -520,9 +520,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.32.tgz",
-            "integrity": "sha512-1qoDB6ooFHx/MGNLsxJq+lIrerk5sc/x5r8s0ym8TDydEJi6Xa7kfx7KFWuOTMxW2kIgH5PHkfNk25RhpUyDJA==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.33.tgz",
+            "integrity": "sha512-NL+qy+FSa/hNTWy+QBWdhx3wBUC3RBeXkbQLoKEl9mDxWsdGgM3kWXpqJC8gXdNqP8CpwpGf4ZTY2rKYPg5J2w==",
             "cpu": [
                 "x64"
             ],
@@ -532,9 +532,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.32.tgz",
-            "integrity": "sha512-Wr8vYhSO356gPFBtLFWt/7DHazVIy9bloemD+hbJqsbLugYUwf0g/LvHwVtdkQXt0enl752aZfMO2y+0EgxKHw==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.33.tgz",
+            "integrity": "sha512-ku3o+kFSMKJSMoyKsh2S61yZSIF3PuI00fJCw/8uHPyqlF5M87MwWsPIq9hl5wYbeeWL9VOkhjB2mzUXJVfmlw==",
             "cpu": [
                 "x64"
             ],
@@ -544,9 +544,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.32.tgz",
-            "integrity": "sha512-o5XXcPOVo1UcCxZF2dbBBixF3QjG3PzEtlPuqI/hqwKoh1QRUVhyYO7kB3WpxUI2NJJOxV4H1wSd7xZZxtDckg==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.33.tgz",
+            "integrity": "sha512-/ZK5LpxDMNgYZpG+5ZjherofHk3VV4twQ1gk12lhrlWWtNmHkYGpVkOJyYF+AHk/YXmw92ApZHRpF1sVXUNRKw==",
             "cpu": [
                 "arm64"
             ],
@@ -556,9 +556,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.32.tgz",
-            "integrity": "sha512-LlbTZ0r7eiaz84UaHQkiLQqpD6LUNSdVD5RDgsolYc7ysMaQMDzablsp54aRWh14cUbQCsq9vNAFY4zl2tlh8A==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.33.tgz",
+            "integrity": "sha512-V8AUbRZvbZC4zuYxwEc5CPq7CTdyeI9AeFFTOPPbTa5jPd3c5VTXcBUpygsJZokIX26q5gjGlTQUF942qrP/hg==",
             "cpu": [
                 "arm64"
             ],
@@ -568,9 +568,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.32.tgz",
-            "integrity": "sha512-24yFcntmcZzHP5bTG7ieOXip6YdO7RLf0eLhiDbPrAZlHk5Efkdt5Upn268pCHZBZo4LwkQOaeka8hbq0QP1YA==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.33.tgz",
+            "integrity": "sha512-DK4d/x4L111KlKaRwY8VQAd8f4GcHml9FfHWxyof+UF2LHjjwp00b/JS12RiA7EZnk6pLKzJvrjG3/OPLuLlww==",
             "cpu": [
                 "x64"
             ],
@@ -580,9 +580,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.32.tgz",
-            "integrity": "sha512-ToyNqXXn1D5dQM9DhvUqoNpbruOCBUXGP7zAOINdm0bG8ENeOGx1nBlwCclU+zWnNzb8EYlOPghLUH5To3bz6g==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.33.tgz",
+            "integrity": "sha512-6lIAk0ZTEPashv4wsFwN4hc7cZRuZGPKoLxOxuDACBaoYNmli22keTJdwtXMSQdIsyDAJXhBlPdwUjvGPghf0A==",
             "cpu": [
                 "x64"
             ],
@@ -592,9 +592,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.32.tgz",
-            "integrity": "sha512-RDSZOcjdEBNVun/FlZswm8t+I1YuYHLmfSvFbQqdgTIi4WD4Fg5JPbRx4IunHz2iISuPm2lodhO1xrRmLgapnw==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.33.tgz",
+            "integrity": "sha512-Nq9uk1kC/pEHBqDkjiLhw9IOgleMQ5lz2oEsZBDwkPLlHSfDo18N25rsjTcwRb2OcwaDEE1dbi4J9WB9kIkP7w==",
             "cpu": [
                 "x64"
             ],
@@ -604,9 +604,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.32.tgz",
-            "integrity": "sha512-RbxX22VXBlcl4L93JKuazDTNn9tcsKYOHKwydoaBtRVEG0pf/m4xmNQ1M5evAbNUBSHDIHTL/lqSuEsL98Mwgg==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.33.tgz",
+            "integrity": "sha512-vyfccgl4dxYOOn0QkYdSxeVJvya3d/uJORXQn1G2ZD3wHGEcogvNZ+po0ZPhy7FOVnzm4q43BLWKfBuX0aGkGQ==",
             "cpu": [
                 "x64"
             ],
@@ -616,9 +616,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.32.tgz",
-            "integrity": "sha512-pcMYZUEdnNlric95+Fu9FC/DKtjK/LiTjeSOxO8HoZHo260mVczhMnkEcBlAOojfimHft1VmasSiLZGIpzNsLg==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.33.tgz",
+            "integrity": "sha512-PydKJ2NMYkbQ8JRwXy5gtZRuvH6A8asVZsSjXucwth3KKhW/p6A6Ycp7UoKB5nWKzPuoBoTAXvPFxIsTANQafQ==",
             "cpu": [
                 "arm64"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.32.tgz",
-            "integrity": "sha512-QjH+ZRrjTFPyL00k1J7L1MuIIbsKYRbKXGrMjX8vV7glQk4AXRpQtl+TLcpPRwv2TV16m2rEAId77erY6ebq6w==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.33.tgz",
+            "integrity": "sha512-g9XC9lF3RWrYIaHg4WDPBj9RbfpxhCs+yasTC/keSHNCP3BYZMcMDbkgYCbnlNK2LDUrfzQNTrpzItNRKsQsbg==",
             "cpu": [
                 "x64"
             ],
@@ -640,9 +640,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.32.tgz",
-            "integrity": "sha512-4OqxP7qiPusTXBdaAMxaYFpokTkkxDsGF40Wd6ZiTYGwqQHm7m0SngFic+M7lpFsToLj+v1A+CBp5bNqywuOSA==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.33.tgz",
+            "integrity": "sha512-gDAUajvHBVjOd9/hNMgu11l9KX5AwFAvxuwnn3tw7g5R/J4yhLJFZ6OZnbd5pxny35+65KcTWYrux1ETb3Jp3Q==",
             "cpu": [
                 "x64"
             ],
@@ -667,27 +667,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.32",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.32.tgz",
-            "integrity": "sha512-BrEq2oLaCZp57WoXNpjnk87KeEazdxp7+AoZLwGeEyGigIhRrOLJoVEvfwHC3fRMV6OY+3Y1lpR083pTjMShNg==",
+            "version": "1.4.33",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.33.tgz",
+            "integrity": "sha512-SUU7Qs11od7dhcga2DN4LTN9Ols/shRcreDKrF0vtvndB/AgxOmuKxA7c3WBJRtI4ujL7JIDLsl6BnFbryuIvA==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.32",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.32",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.32",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.32",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.32",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.32",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.32"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.33",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.33",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.33",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.33",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.33",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.33",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.33"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.1",
+    "version": "1.0.1-rc.2",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -36,7 +36,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.32",
+        "@vrsen/agentswarm": "1.4.33",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.1"
+version = "1.0.1-rc.2"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"


### PR DESCRIPTION
## What changed

This makes the OpenSwarm package pass its product profile into both TUI paths:

- release workflow builds the TUI with `AGENTSWARM_PRODUCT_*` values for OpenSwarm
- npm wrapper fallback runs the packaged AgentSwarm UI with the same OpenSwarm profile

## Why

OpenSwarm can fall back to the packaged AgentSwarm UI when a custom OpenSwarm binary is unavailable. This keeps that fallback path configured as OpenSwarm once the AgentSwarm foundation supports generic downstream product profiles.

## Dependency

Depends on VRSEN/agentswarm-cli#222 and a follow-up bump of `AGENTSWARM_CLI_VERSION` from `1.4.32` to the first AgentSwarm TUI release that contains product-profile support.

## Checks

- `git diff --check`
- `node --check bin/openswarm`
- Local fallback smoke confirmed the wrapper passes the generic OpenSwarm profile env and Python UTF-8 env into the packaged fallback binary.
