### PR TITLE
chore: prepare OpenSwarm rc.3

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AGENTSWARM_CLI_VERSION: 1.4.33
+  AGENTSWARM_CLI_VERSION: 1.4.34
 
 jobs:
   prepare:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
-          ref: v1.4.33
+          ref: v1.4.34
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:
@@ -43,12 +43,12 @@ jobs:
           AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
           AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
           AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py,agency.py
-          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.2
+          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.3
         run: |
           bun install
           cd packages/opencode
           bun run script/build.ts --single --skip-install
-          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.2"
+          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.3"
       - name: Test startup
         shell: bash
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.2",
+    "version": "1.0.1-rc.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.2",
+            "version": "1.0.1-rc.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.33",
+                "@vrsen/agentswarm": "1.4.34",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -496,21 +496,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.33.tgz",
-            "integrity": "sha512-KEZ42I0o6XR9bwqpgvMF6Z1GwH7QvDsks64pNl2kP7zMu/E2EyQIFFvT2V6x1E7geEsM0GczKUt+pXYrJ/chyw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.34.tgz",
+            "integrity": "sha512-6cLzI/4I//Q2LeU90VG54zD6mqdGJ5OcdpXB7xIyrNgfJx6LTHjZ4qmvwKvaS+ZdMs43BZkr+7v9FSeVtvMWbw==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.33"
+                "agentswarm-cli": "1.4.34"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.33.tgz",
-            "integrity": "sha512-luQIcapPhiwcIam5EjPd4kPgRgCidkhWZAbf1m2Oh04QgRzJR3KNEN44ZyKrh+d0CoJUmVoFi6FkvoFSVISZog==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.34.tgz",
+            "integrity": "sha512-UHUB3yHS4RdFeywjtxfYbvpFhi0R9qqKsFEpIf4ADyVB4h+Ez2SGpRHVehR06ocuUOsUAbPOEvi9LHykvCok4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -520,9 +520,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.33.tgz",
-            "integrity": "sha512-NL+qy+FSa/hNTWy+QBWdhx3wBUC3RBeXkbQLoKEl9mDxWsdGgM3kWXpqJC8gXdNqP8CpwpGf4ZTY2rKYPg5J2w==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.34.tgz",
+            "integrity": "sha512-cck3Cz4arffd0QoyrMvMbMArwNLAKc4NJBHnO2SHLEjQusUDTKRZt+XcHg/ygYx6RplHaIYHyFkl47cXjF+uAQ==",
             "cpu": [
                 "x64"
             ],
@@ -532,9 +532,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-ku3o+kFSMKJSMoyKsh2S61yZSIF3PuI00fJCw/8uHPyqlF5M87MwWsPIq9hl5wYbeeWL9VOkhjB2mzUXJVfmlw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-wO+9EKyPPY3PnVePzfq262j8xGoeXO0PoUs7py/brFV9vtacQ2mb/saYwJtADTKQWuudjdMT02m/c46mky6P1Q==",
             "cpu": [
                 "x64"
             ],
@@ -544,9 +544,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.33.tgz",
-            "integrity": "sha512-/ZK5LpxDMNgYZpG+5ZjherofHk3VV4twQ1gk12lhrlWWtNmHkYGpVkOJyYF+AHk/YXmw92ApZHRpF1sVXUNRKw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.34.tgz",
+            "integrity": "sha512-WNIiz6CQlo7nBxtTAr6+J18bT9mWn4wh64oMVO0GEdrdB7TR6HxUOnf91N3Y1JOoqEhTSYcke7VnDddt5Oa0rg==",
             "cpu": [
                 "arm64"
             ],
@@ -556,9 +556,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.33.tgz",
-            "integrity": "sha512-V8AUbRZvbZC4zuYxwEc5CPq7CTdyeI9AeFFTOPPbTa5jPd3c5VTXcBUpygsJZokIX26q5gjGlTQUF942qrP/hg==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.34.tgz",
+            "integrity": "sha512-khcWx+nmFfxaKfLD5OuSUrEKe3HV7sFQURXFvcxTjxwFFMGoArRR/HZO+Oe2Y+Vip+cO6XAhTMQVXUHkhSOxQA==",
             "cpu": [
                 "arm64"
             ],
@@ -568,9 +568,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.33.tgz",
-            "integrity": "sha512-DK4d/x4L111KlKaRwY8VQAd8f4GcHml9FfHWxyof+UF2LHjjwp00b/JS12RiA7EZnk6pLKzJvrjG3/OPLuLlww==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.34.tgz",
+            "integrity": "sha512-Tc3b/td5jDprlz7ByifPvea8cPKXW/4kXr0K8gSxbYor7qs1j31KEqguCSKUh5X4De0+cbfMJU5kf6rcbWRnSw==",
             "cpu": [
                 "x64"
             ],
@@ -580,9 +580,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-6lIAk0ZTEPashv4wsFwN4hc7cZRuZGPKoLxOxuDACBaoYNmli22keTJdwtXMSQdIsyDAJXhBlPdwUjvGPghf0A==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-Vi7gyUPEvWfwzG6CUfWGPyeI7FEHZ6Xar6Tnax3fDu9XakeVjNLPJByfWAEepYONLlZ/2asSISgsp9PJpkwsYg==",
             "cpu": [
                 "x64"
             ],
@@ -592,9 +592,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.33.tgz",
-            "integrity": "sha512-Nq9uk1kC/pEHBqDkjiLhw9IOgleMQ5lz2oEsZBDwkPLlHSfDo18N25rsjTcwRb2OcwaDEE1dbi4J9WB9kIkP7w==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.34.tgz",
+            "integrity": "sha512-UPUcGhA2Z+VTXsqk6grweVEoffB0wN8j9bT4I5vhHP1jMFJJU34NSRZG07Tfc/l7AgRyEXquC52YUHn8KA5z8g==",
             "cpu": [
                 "x64"
             ],
@@ -604,9 +604,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.33.tgz",
-            "integrity": "sha512-vyfccgl4dxYOOn0QkYdSxeVJvya3d/uJORXQn1G2ZD3wHGEcogvNZ+po0ZPhy7FOVnzm4q43BLWKfBuX0aGkGQ==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.34.tgz",
+            "integrity": "sha512-986/egNVEIhb7C4WWDJQ20CeDarUw6J//kSVR7Rwrd1Pu2sOdi9rS8VnwlUU5QqPGxk0Zh1fnFCyFxngA2bmbA==",
             "cpu": [
                 "x64"
             ],
@@ -616,9 +616,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.33.tgz",
-            "integrity": "sha512-PydKJ2NMYkbQ8JRwXy5gtZRuvH6A8asVZsSjXucwth3KKhW/p6A6Ycp7UoKB5nWKzPuoBoTAXvPFxIsTANQafQ==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.34.tgz",
+            "integrity": "sha512-xDAiwz38fYEwK8tzqGBSEhesefu1xVrER/U/5jmIx7K4ldd3gPShLo7PWnJq7UOabtSA2b78yE7rfm/GhoqijA==",
             "cpu": [
                 "arm64"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.33.tgz",
-            "integrity": "sha512-g9XC9lF3RWrYIaHg4WDPBj9RbfpxhCs+yasTC/keSHNCP3BYZMcMDbkgYCbnlNK2LDUrfzQNTrpzItNRKsQsbg==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.34.tgz",
+            "integrity": "sha512-/Yuhtv8VetHfhPySPXwBTzyCxZeXdJ+W+t4klkmIJGDxPiZqkXc00vBzM4f+mgvwDNmh3F8y4sOUIQOcKXkz3Q==",
             "cpu": [
                 "x64"
             ],
@@ -640,9 +640,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-gDAUajvHBVjOd9/hNMgu11l9KX5AwFAvxuwnn3tw7g5R/J4yhLJFZ6OZnbd5pxny35+65KcTWYrux1ETb3Jp3Q==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-x3CguvjJW8ascO13MnzDpZeT+qqs3NiUWnt+Z5mDOdITcYaCTc5CkncNCBYHRLgtLzAeMt/qcADwZRb1I5G4PQ==",
             "cpu": [
                 "x64"
             ],
@@ -667,27 +667,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.33.tgz",
-            "integrity": "sha512-SUU7Qs11od7dhcga2DN4LTN9Ols/shRcreDKrF0vtvndB/AgxOmuKxA7c3WBJRtI4ujL7JIDLsl6BnFbryuIvA==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.34.tgz",
+            "integrity": "sha512-wYLUFpsElbzz10gLB6KB6GNgd0j4SIkckiXnmy0onCWMoHoCZv8LA4VjX5iiOtT4HH1V7xP2DHJwMqAgSKKAHQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.33"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.34"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.2",
+    "version": "1.0.1-rc.3",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -36,7 +36,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.33",
+        "@vrsen/agentswarm": "1.4.34",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.2"
+version = "1.0.1-rc.3"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- bump OpenSwarm prerelease metadata to `1.0.1-rc.3`
- pin OpenSwarm builds and package installs to `@vrsen/agentswarm@1.4.34`
- update the macOS release smoke workflow to build from AgentSwarm `v1.4.34`

## Checks
- `npm install --package-lock-only --ignore-scripts`
- local package install smoke with a served fake OpenSwarm TUI binary returned `1.0.1-rc.3`
- version consistency check across `package.json`, `package-lock.json`, and `pyproject.toml`
- `git diff --check HEAD`
- `codex review --base origin/main -c model="gpt-5.5" -c model_reasoning_effort="high"`
