### PR TITLE
test: add live OpenSwarm run-mode smoke

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AGENTSWARM_CLI_VERSION: 1.4.33
+  AGENTSWARM_CLI_VERSION: 1.4.34
 
 jobs:
   prepare:

--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -1,0 +1,21 @@
+name: Live Run Mode Smoke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run installed OpenSwarm through Agency Swarm Run mode
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python3 scripts/smoke-run-mode.py --source local

--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -2,6 +2,20 @@ name: Live Run Mode Smoke
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/live-run-mode-smoke.yml'
+      - 'bin/openswarm'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'pyproject.toml'
+      - 'scripts/smoke-run-mode.py'
+      - 'swarm.py'
+      - '*_agent/**'
+      - 'data_analyst_agent/**'
+      - 'deep_research/**'
+      - 'orchestrator/**'
+      - 'virtual_assistant/**'
 
 jobs:
   smoke:

--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Run installed OpenSwarm through Agency Swarm Run mode
+      - name: Verify OpenSwarm agent roster through TUI
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: python3 scripts/smoke-run-mode.py --source local
+        run: python3 scripts/smoke-run-mode.py --source local --check agents
+      - name: Verify live Agency Swarm Run-mode prompt
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: python3 scripts/smoke-run-mode.py --source local --check prompt

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
-          ref: v1.4.33
+          ref: v1.4.34
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:
@@ -43,12 +43,12 @@ jobs:
           AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
           AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
           AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py,agency.py
-          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.2
+          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.3
         run: |
           bun install
           cd packages/opencode
           bun run script/build.ts --single --skip-install
-          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.2"
+          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.3"
       - name: Test startup
         shell: bash
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.2",
+    "version": "1.0.1-rc.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.2",
+            "version": "1.0.1-rc.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.33",
+                "@vrsen/agentswarm": "1.4.34",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -496,21 +496,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.33.tgz",
-            "integrity": "sha512-KEZ42I0o6XR9bwqpgvMF6Z1GwH7QvDsks64pNl2kP7zMu/E2EyQIFFvT2V6x1E7geEsM0GczKUt+pXYrJ/chyw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.34.tgz",
+            "integrity": "sha512-6cLzI/4I//Q2LeU90VG54zD6mqdGJ5OcdpXB7xIyrNgfJx6LTHjZ4qmvwKvaS+ZdMs43BZkr+7v9FSeVtvMWbw==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.33"
+                "agentswarm-cli": "1.4.34"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.33.tgz",
-            "integrity": "sha512-luQIcapPhiwcIam5EjPd4kPgRgCidkhWZAbf1m2Oh04QgRzJR3KNEN44ZyKrh+d0CoJUmVoFi6FkvoFSVISZog==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.34.tgz",
+            "integrity": "sha512-UHUB3yHS4RdFeywjtxfYbvpFhi0R9qqKsFEpIf4ADyVB4h+Ez2SGpRHVehR06ocuUOsUAbPOEvi9LHykvCok4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -520,9 +520,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.33.tgz",
-            "integrity": "sha512-NL+qy+FSa/hNTWy+QBWdhx3wBUC3RBeXkbQLoKEl9mDxWsdGgM3kWXpqJC8gXdNqP8CpwpGf4ZTY2rKYPg5J2w==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.34.tgz",
+            "integrity": "sha512-cck3Cz4arffd0QoyrMvMbMArwNLAKc4NJBHnO2SHLEjQusUDTKRZt+XcHg/ygYx6RplHaIYHyFkl47cXjF+uAQ==",
             "cpu": [
                 "x64"
             ],
@@ -532,9 +532,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-ku3o+kFSMKJSMoyKsh2S61yZSIF3PuI00fJCw/8uHPyqlF5M87MwWsPIq9hl5wYbeeWL9VOkhjB2mzUXJVfmlw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-wO+9EKyPPY3PnVePzfq262j8xGoeXO0PoUs7py/brFV9vtacQ2mb/saYwJtADTKQWuudjdMT02m/c46mky6P1Q==",
             "cpu": [
                 "x64"
             ],
@@ -544,9 +544,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.33.tgz",
-            "integrity": "sha512-/ZK5LpxDMNgYZpG+5ZjherofHk3VV4twQ1gk12lhrlWWtNmHkYGpVkOJyYF+AHk/YXmw92ApZHRpF1sVXUNRKw==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.34.tgz",
+            "integrity": "sha512-WNIiz6CQlo7nBxtTAr6+J18bT9mWn4wh64oMVO0GEdrdB7TR6HxUOnf91N3Y1JOoqEhTSYcke7VnDddt5Oa0rg==",
             "cpu": [
                 "arm64"
             ],
@@ -556,9 +556,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.33.tgz",
-            "integrity": "sha512-V8AUbRZvbZC4zuYxwEc5CPq7CTdyeI9AeFFTOPPbTa5jPd3c5VTXcBUpygsJZokIX26q5gjGlTQUF942qrP/hg==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.34.tgz",
+            "integrity": "sha512-khcWx+nmFfxaKfLD5OuSUrEKe3HV7sFQURXFvcxTjxwFFMGoArRR/HZO+Oe2Y+Vip+cO6XAhTMQVXUHkhSOxQA==",
             "cpu": [
                 "arm64"
             ],
@@ -568,9 +568,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.33.tgz",
-            "integrity": "sha512-DK4d/x4L111KlKaRwY8VQAd8f4GcHml9FfHWxyof+UF2LHjjwp00b/JS12RiA7EZnk6pLKzJvrjG3/OPLuLlww==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.34.tgz",
+            "integrity": "sha512-Tc3b/td5jDprlz7ByifPvea8cPKXW/4kXr0K8gSxbYor7qs1j31KEqguCSKUh5X4De0+cbfMJU5kf6rcbWRnSw==",
             "cpu": [
                 "x64"
             ],
@@ -580,9 +580,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-6lIAk0ZTEPashv4wsFwN4hc7cZRuZGPKoLxOxuDACBaoYNmli22keTJdwtXMSQdIsyDAJXhBlPdwUjvGPghf0A==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-Vi7gyUPEvWfwzG6CUfWGPyeI7FEHZ6Xar6Tnax3fDu9XakeVjNLPJByfWAEepYONLlZ/2asSISgsp9PJpkwsYg==",
             "cpu": [
                 "x64"
             ],
@@ -592,9 +592,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.33.tgz",
-            "integrity": "sha512-Nq9uk1kC/pEHBqDkjiLhw9IOgleMQ5lz2oEsZBDwkPLlHSfDo18N25rsjTcwRb2OcwaDEE1dbi4J9WB9kIkP7w==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.34.tgz",
+            "integrity": "sha512-UPUcGhA2Z+VTXsqk6grweVEoffB0wN8j9bT4I5vhHP1jMFJJU34NSRZG07Tfc/l7AgRyEXquC52YUHn8KA5z8g==",
             "cpu": [
                 "x64"
             ],
@@ -604,9 +604,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.33.tgz",
-            "integrity": "sha512-vyfccgl4dxYOOn0QkYdSxeVJvya3d/uJORXQn1G2ZD3wHGEcogvNZ+po0ZPhy7FOVnzm4q43BLWKfBuX0aGkGQ==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.34.tgz",
+            "integrity": "sha512-986/egNVEIhb7C4WWDJQ20CeDarUw6J//kSVR7Rwrd1Pu2sOdi9rS8VnwlUU5QqPGxk0Zh1fnFCyFxngA2bmbA==",
             "cpu": [
                 "x64"
             ],
@@ -616,9 +616,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.33.tgz",
-            "integrity": "sha512-PydKJ2NMYkbQ8JRwXy5gtZRuvH6A8asVZsSjXucwth3KKhW/p6A6Ycp7UoKB5nWKzPuoBoTAXvPFxIsTANQafQ==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.34.tgz",
+            "integrity": "sha512-xDAiwz38fYEwK8tzqGBSEhesefu1xVrER/U/5jmIx7K4ldd3gPShLo7PWnJq7UOabtSA2b78yE7rfm/GhoqijA==",
             "cpu": [
                 "arm64"
             ],
@@ -628,9 +628,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.33.tgz",
-            "integrity": "sha512-g9XC9lF3RWrYIaHg4WDPBj9RbfpxhCs+yasTC/keSHNCP3BYZMcMDbkgYCbnlNK2LDUrfzQNTrpzItNRKsQsbg==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.34.tgz",
+            "integrity": "sha512-/Yuhtv8VetHfhPySPXwBTzyCxZeXdJ+W+t4klkmIJGDxPiZqkXc00vBzM4f+mgvwDNmh3F8y4sOUIQOcKXkz3Q==",
             "cpu": [
                 "x64"
             ],
@@ -640,9 +640,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.33.tgz",
-            "integrity": "sha512-gDAUajvHBVjOd9/hNMgu11l9KX5AwFAvxuwnn3tw7g5R/J4yhLJFZ6OZnbd5pxny35+65KcTWYrux1ETb3Jp3Q==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.34.tgz",
+            "integrity": "sha512-x3CguvjJW8ascO13MnzDpZeT+qqs3NiUWnt+Z5mDOdITcYaCTc5CkncNCBYHRLgtLzAeMt/qcADwZRb1I5G4PQ==",
             "cpu": [
                 "x64"
             ],
@@ -667,27 +667,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.33.tgz",
-            "integrity": "sha512-SUU7Qs11od7dhcga2DN4LTN9Ols/shRcreDKrF0vtvndB/AgxOmuKxA7c3WBJRtI4ujL7JIDLsl6BnFbryuIvA==",
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.34.tgz",
+            "integrity": "sha512-wYLUFpsElbzz10gLB6KB6GNgd0j4SIkckiXnmy0onCWMoHoCZv8LA4VjX5iiOtT4HH1V7xP2DHJwMqAgSKKAHQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.33",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.33"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.34",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.34"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "package-lock.json"
     ],
     "scripts": {
-        "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
+        "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\"",
+        "smoke:run-mode": "python3 scripts/smoke-run-mode.py"
     },
     "dependencies": {
         "@vrsen/agentswarm": "1.4.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.2",
+    "version": "1.0.1-rc.3",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -36,7 +36,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.33",
+        "@vrsen/agentswarm": "1.4.34",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.2"
+version = "1.0.1-rc.3"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Live smoke test for the installed OpenSwarm Run-mode path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import pty
+import re
+import select
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+from collections.abc import Sequence
+
+
+DEFAULT_PROMPT = "Reply exactly OPEN_SWARM_RUN_SMOKE_OK."
+DEFAULT_EXPECT = "OPEN_SWARM_RUN_SMOKE_OK"
+
+
+def run(cmd: Sequence[str], *, cwd: pathlib.Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, env=env, text=True, capture_output=True, check=True, timeout=600)
+
+
+def latest_pack_stdout_line(stdout: str) -> str:
+    for line in reversed(stdout.splitlines()):
+        value = line.strip()
+        if value:
+            return value
+    raise RuntimeError("npm pack did not print a tarball name")
+
+
+def install_package(repo: pathlib.Path, root: pathlib.Path, source: str, npm_spec: str, env: dict[str, str]) -> pathlib.Path:
+    run(["npm", "init", "-y"], cwd=root, env=env)
+    if source == "local":
+        packed = run(["npm", "pack"], cwd=repo, env=env)
+        tarball = repo / latest_pack_stdout_line(packed.stdout)
+        try:
+            run(["npm", "install", str(tarball)], cwd=root, env=env)
+        finally:
+            tarball.unlink(missing_ok=True)
+    else:
+        run(["npm", "install", npm_spec], cwd=root, env=env)
+
+    launcher = root / "node_modules" / ".bin" / "openswarm"
+    if not launcher.exists():
+        raise RuntimeError(f"openswarm launcher was not installed at {launcher}")
+    package_dir = root / "node_modules" / "@vrsen" / "openswarm"
+    if not package_dir.exists():
+        raise RuntimeError(f"OpenSwarm package directory was not installed at {package_dir}")
+    return launcher
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+
+
+def write(fd: int, text: str) -> None:
+    os.write(fd, text.encode())
+
+
+def terminate(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGINT)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=10)
+            return
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                return
+            process.wait(timeout=10)
+
+
+def terminate_processes_under(root: pathlib.Path) -> None:
+    match = str(root)
+    current = os.getpid()
+    try:
+        found = subprocess.run(["pgrep", "-f", match], text=True, capture_output=True, check=False)
+    except FileNotFoundError:
+        return
+    pids = [int(line) for line in found.stdout.splitlines() if line.strip().isdigit()]
+    for pid in pids:
+        if pid != current:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+    if pids:
+        time.sleep(2)
+    for pid in pids:
+        if pid != current:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def set_window_size(fd: int, rows: int = 45, columns: int = 180) -> None:
+    size = struct.pack("HHHH", rows, columns, 0, 0)
+    termios.tcsetwinsize(fd, (rows, columns))
+    try:
+        import fcntl
+
+        fcntl.ioctl(fd, termios.TIOCSWINSZ, size)
+    except Exception:
+        pass
+
+
+def run_tui_smoke(
+    launcher: pathlib.Path,
+    package_dir: pathlib.Path,
+    root: pathlib.Path,
+    env: dict[str, str],
+    prompt: str,
+    expected: str,
+    timeout: int,
+) -> str:
+    master_fd, slave_fd = pty.openpty()
+    set_window_size(slave_fd)
+    process = subprocess.Popen(
+        [str(launcher)],
+        cwd=package_dir,
+        env=env,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        start_new_session=True,
+    )
+    os.close(slave_fd)
+
+    raw = ""
+    plain = ""
+    sent_confirm = False
+    sent_prompt = False
+    deadline = time.monotonic() + timeout
+    expected_compact = re.sub(r"\s+", "", expected)
+
+    try:
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                break
+            ready, _, _ = select.select([master_fd], [], [], 1)
+            if not ready:
+                continue
+            chunk = os.read(master_fd, 8192)
+            if not chunk:
+                continue
+            decoded = chunk.decode(errors="replace")
+            raw += decoded
+            plain = strip_ansi(raw)
+            compact = re.sub(r"\s+", "", plain)
+
+            if not sent_confirm and "Createalocal`.venv`inthisproject?" in compact:
+                write(master_fd, "\r")
+                sent_confirm = True
+
+            if not sent_prompt and "AgencySwarmDefault" in compact and "ctrl+pcommands" in compact:
+                write(master_fd, prompt + "\r")
+                sent_prompt = True
+
+            if expected in plain or expected_compact in compact:
+                return plain
+    finally:
+        terminate(process)
+        terminate_processes_under(root)
+        os.close(master_fd)
+
+    log_path = root / "openswarm-run-mode-smoke.log"
+    log_path.write_text(plain or raw, encoding="utf-8")
+    raise RuntimeError(
+        "OpenSwarm Run-mode smoke test did not reach the expected response. "
+        f"sent_confirm={sent_confirm} sent_prompt={sent_prompt} log={log_path}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", choices=["local", "npm"], default="local")
+    parser.add_argument("--npm-spec")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--expect", default=DEFAULT_EXPECT)
+    parser.add_argument("--timeout", type=int, default=1200)
+    parser.add_argument("--keep-root", action="store_true")
+    args = parser.parse_args()
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY is required for this live OpenSwarm Run-mode smoke test")
+
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    package_json = json.loads((repo / "package.json").read_text(encoding="utf-8"))
+    npm_spec = args.npm_spec or f"{package_json['name']}@{package_json['version']}"
+    root = pathlib.Path(tempfile.mkdtemp(prefix="openswarm-run-mode-smoke-"))
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONUTF8": "1",
+            "PYTHONIOENCODING": "utf-8",
+            "TERM": "xterm-256color",
+            "OPENCODE_AUTH_CONTENT": json.dumps({"openai": {"type": "api", "key": api_key}}),
+            "XDG_DATA_HOME": str(root / "xdg-data"),
+            "XDG_CONFIG_HOME": str(root / "xdg-config"),
+            "XDG_CACHE_HOME": str(root / "xdg-cache"),
+            "XDG_STATE_HOME": str(root / "xdg-state"),
+        }
+    )
+
+    try:
+        launcher = install_package(repo, root, args.source, npm_spec, env)
+        package_dir = root / "node_modules" / "@vrsen" / "openswarm"
+        plain = run_tui_smoke(launcher, package_dir, root, env, args.prompt, args.expect, args.timeout)
+        if "Agency Swarm Default" not in plain:
+            raise RuntimeError("Smoke response was seen, but Agency Swarm Run mode was not detected")
+        print(f"OpenSwarm Run-mode smoke passed in {package_dir}")
+        return 0
+    finally:
+        if args.keep_root:
+            print(f"Kept smoke root: {root}")
+        else:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        print(f"FAILED: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -244,13 +244,16 @@ def main() -> int:
     parser.add_argument("--keep-root", action="store_true")
     args = parser.parse_args()
 
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENAI_API_KEY is required for this live OpenSwarm Run-mode smoke test")
-
     repo = pathlib.Path(__file__).resolve().parents[1]
     package_json = json.loads((repo / "package.json").read_text(encoding="utf-8"))
     npm_spec = args.npm_spec or f"{package_json['name']}@{package_json['version']}"
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key and args.check == "prompt" and os.environ.get("GITHUB_ACTIONS") == "true":
+        print("Skipped OpenSwarm live prompt smoke because OPENAI_API_KEY is not configured")
+        return 0
+    if not api_key and args.check in {"all", "prompt"}:
+        raise RuntimeError("OPENAI_API_KEY is required for the live prompt smoke test")
+    auth_key = api_key or "dummy-openai-key-for-agent-roster-smoke"
     root = pathlib.Path(tempfile.mkdtemp(prefix="openswarm-run-mode-smoke-"))
     env = os.environ.copy()
     env.update(
@@ -258,7 +261,7 @@ def main() -> int:
             "PYTHONUTF8": "1",
             "PYTHONIOENCODING": "utf-8",
             "TERM": "xterm-256color",
-            "OPENCODE_AUTH_CONTENT": json.dumps({"openai": {"type": "api", "key": api_key}}),
+            "OPENCODE_AUTH_CONTENT": json.dumps({"openai": {"type": "api", "key": auth_key}}),
             "XDG_DATA_HOME": str(root / "xdg-data"),
             "XDG_CONFIG_HOME": str(root / "xdg-config"),
             "XDG_CACHE_HOME": str(root / "xdg-cache"),

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -23,6 +23,17 @@ from collections.abc import Sequence
 
 DEFAULT_PROMPT = "Reply exactly OPEN_SWARM_RUN_SMOKE_OK."
 DEFAULT_EXPECT = "OPEN_SWARM_RUN_SMOKE_OK"
+EXPECTED_AGENCY_NAME = "OpenSwarm"
+EXPECTED_ENTRY_AGENT = "Orchestrator"
+EXPECTED_SPECIALIST_AGENTS = [
+    "General Agent",
+    "Slides Agent",
+    "Deep Research Agent",
+    "Data Analyst",
+    "Docs Agent",
+    "Video Agent",
+    "Image Agent",
+]
 
 
 def run(cmd: Sequence[str], *, cwd: pathlib.Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -64,6 +75,10 @@ def strip_ansi(text: str) -> str:
 
 def write(fd: int, text: str) -> None:
     os.write(fd, text.encode())
+
+
+def compact(text: str) -> str:
+    return re.sub(r"\s+", "", text)
 
 
 def terminate(process: subprocess.Popen[bytes]) -> None:
@@ -123,6 +138,7 @@ def run_tui_smoke(
     package_dir: pathlib.Path,
     root: pathlib.Path,
     env: dict[str, str],
+    check: str,
     prompt: str,
     expected: str,
     timeout: int,
@@ -143,34 +159,65 @@ def run_tui_smoke(
     raw = ""
     plain = ""
     sent_confirm = False
+    sent_agents_command = False
+    verified_agents = False
+    closed_agents_at: float | None = None
     sent_prompt = False
+    saw_expected = False
     deadline = time.monotonic() + timeout
-    expected_compact = re.sub(r"\s+", "", expected)
+    expected_compact = compact(expected)
+    expected_agent_terms = [EXPECTED_AGENCY_NAME, EXPECTED_ENTRY_AGENT, *EXPECTED_SPECIALIST_AGENTS]
+    expected_agent_compact = [compact(term) for term in expected_agent_terms]
 
     try:
         while time.monotonic() < deadline:
             if process.poll() is not None:
                 break
             ready, _, _ = select.select([master_fd], [], [], 1)
-            if not ready:
-                continue
-            chunk = os.read(master_fd, 8192)
-            if not chunk:
-                continue
-            decoded = chunk.decode(errors="replace")
-            raw += decoded
-            plain = strip_ansi(raw)
-            compact = re.sub(r"\s+", "", plain)
+            if ready:
+                chunk = os.read(master_fd, 8192)
+                if chunk:
+                    decoded = chunk.decode(errors="replace")
+                    raw += decoded
+                    plain = strip_ansi(raw)
 
-            if not sent_confirm and "Createalocal`.venv`inthisproject?" in compact:
+            compact_plain = compact(plain)
+
+            if not sent_confirm and "Createalocal`.venv`inthisproject?" in compact_plain:
                 write(master_fd, "\r")
                 sent_confirm = True
 
-            if not sent_prompt and "AgencySwarmDefault" in compact and "ctrl+pcommands" in compact:
+            run_mode_ready = "AgencySwarmDefault" in compact_plain and "ctrl+pcommands" in compact_plain
+
+            if check in {"agents", "all"} and not sent_agents_command and run_mode_ready:
+                write(master_fd, "/agents\r")
+                sent_agents_command = True
+
+            if sent_agents_command and not verified_agents and "Selectswarm" in compact_plain:
+                missing = [term for term, packed in zip(expected_agent_terms, expected_agent_compact) if packed not in compact_plain]
+                if not missing:
+                    verified_agents = True
+                    write(master_fd, "\x1b")
+                    closed_agents_at = time.monotonic()
+                    if check == "agents":
+                        return plain
+
+            if check == "prompt" and run_mode_ready:
+                verified_agents = True
+                closed_agents_at = closed_agents_at or time.monotonic()
+
+            if (
+                check in {"prompt", "all"}
+                and verified_agents
+                and not sent_prompt
+                and closed_agents_at is not None
+                and time.monotonic() - closed_agents_at > 0.5
+            ):
                 write(master_fd, prompt + "\r")
                 sent_prompt = True
 
-            if expected in plain or expected_compact in compact:
+            if expected in plain or expected_compact in compact_plain:
+                saw_expected = True
                 return plain
     finally:
         terminate(process)
@@ -181,7 +228,8 @@ def run_tui_smoke(
     log_path.write_text(plain or raw, encoding="utf-8")
     raise RuntimeError(
         "OpenSwarm Run-mode smoke test did not reach the expected response. "
-        f"sent_confirm={sent_confirm} sent_prompt={sent_prompt} log={log_path}"
+        f"sent_confirm={sent_confirm} sent_agents_command={sent_agents_command} "
+        f"verified_agents={verified_agents} sent_prompt={sent_prompt} saw_expected={saw_expected} log={log_path}"
     )
 
 
@@ -189,6 +237,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", choices=["local", "npm"], default="local")
     parser.add_argument("--npm-spec")
+    parser.add_argument("--check", choices=["all", "agents", "prompt"], default="all")
     parser.add_argument("--prompt", default=DEFAULT_PROMPT)
     parser.add_argument("--expect", default=DEFAULT_EXPECT)
     parser.add_argument("--timeout", type=int, default=1200)
@@ -220,10 +269,14 @@ def main() -> int:
     try:
         launcher = install_package(repo, root, args.source, npm_spec, env)
         package_dir = root / "node_modules" / "@vrsen" / "openswarm"
-        plain = run_tui_smoke(launcher, package_dir, root, env, args.prompt, args.expect, args.timeout)
+        plain = run_tui_smoke(launcher, package_dir, root, env, args.check, args.prompt, args.expect, args.timeout)
         if "Agency Swarm Default" not in plain:
             raise RuntimeError("Smoke response was seen, but Agency Swarm Run mode was not detected")
-        print(f"OpenSwarm Run-mode smoke passed in {package_dir}")
+        if args.check in {"agents", "all"}:
+            print(f"OpenSwarm /agents smoke passed with {len(EXPECTED_SPECIALIST_AGENTS)} specialists visible")
+        if args.check in {"prompt", "all"}:
+            print("OpenSwarm live prompt smoke passed")
+        print(f"OpenSwarm smoke root package: {package_dir}")
         return 0
     finally:
         if args.keep_root:


### PR DESCRIPTION
## Summary
- add a live smoke script that installs OpenSwarm, launches the local Agency Swarm project, and sends a real Run-mode prompt
- add a manual GitHub Actions workflow for the same live smoke path
- expose the smoke script through `npm run smoke:run-mode`

## Checks
- `python3 -m py_compile scripts/smoke-run-mode.py`
- `npm run smoke:run-mode -- --help`
- local package live smoke: passed
- published `@vrsen/openswarm@1.0.1-rc.3` live smoke: passed
- `git diff --check`