### PR TITLE
Move OpenSwarm product config into the launcher

### DIFF
--- a/bin/openswarm
+++ b/bin/openswarm
@@ -30,6 +30,16 @@ const productTuiLogoRight = [
   '╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝',
 ]
 const productWordmarkLines = productTuiLogoLeft.map((line, index) => `${line} ${productTuiLogoRight[index] ?? ''}`.trimEnd())
+const productAddons = [
+  { id: 'search', title: 'Web Search', keys: ['SEARCH_API_KEY'] },
+  { id: 'anthropic', title: 'Anthropic Claude', keys: ['ANTHROPIC_API_KEY'], excludeProviders: ['anthropic'] },
+  { id: 'composio', title: 'Composio', keys: ['COMPOSIO_API_KEY', 'COMPOSIO_USER_ID'] },
+  { id: 'google', title: 'Google Gemini', keys: ['GOOGLE_API_KEY'], excludeProviders: ['google'] },
+  { id: 'fal', title: 'Fal.ai', keys: ['FAL_KEY'] },
+  { id: 'pexels', title: 'Pexels', keys: ['PEXELS_API_KEY'] },
+  { id: 'pixabay', title: 'Pixabay', keys: ['PIXABAY_API_KEY'] },
+  { id: 'unsplash', title: 'Unsplash', keys: ['UNSPLASH_ACCESS_KEY'] },
+]
 const downstreamEnv = {
   AGENTSWARM_PRODUCT_DISPLAY_NAME: 'OpenSwarm',
   AGENTSWARM_PRODUCT_COMMAND: 'openswarm',
@@ -47,7 +57,7 @@ const downstreamEnv = {
   AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: JSON.stringify(productTuiLogoRight),
   AGENTSWARM_PRODUCT_WORDMARK_LINES: JSON.stringify(productWordmarkLines),
   AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: 'standalone',
-  AGENTSWARM_PRODUCT_ENABLE_ADDONS: 'true',
+  AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(productAddons),
   AGENTSWARM_PRODUCT_VERSION: packageJson.version,
 }
 

--- a/bin/openswarm
+++ b/bin/openswarm
@@ -40,6 +40,15 @@ const productAddons = [
   { id: 'pixabay', title: 'Pixabay', keys: ['PIXABAY_API_KEY'] },
   { id: 'unsplash', title: 'Unsplash', keys: ['UNSPLASH_ACCESS_KEY'] },
 ]
+function resolveStateRoot() {
+  const explicit = process.env.OPENSWARM_STATE_ROOT && process.env.OPENSWARM_STATE_ROOT.trim()
+  if (explicit) return path.resolve(explicit)
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'OpenSwarm')
+  }
+  return path.join(os.homedir(), '.openswarm')
+}
+
 const downstreamEnv = {
   AGENTSWARM_PRODUCT_DISPLAY_NAME: 'OpenSwarm',
   AGENTSWARM_PRODUCT_COMMAND: 'openswarm',
@@ -58,6 +67,7 @@ const downstreamEnv = {
   AGENTSWARM_PRODUCT_WORDMARK_LINES: JSON.stringify(productWordmarkLines),
   AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: 'standalone',
   AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(productAddons),
+  AGENTSWARM_PRODUCT_STATE_ROOT: resolveStateRoot(),
   AGENTSWARM_PRODUCT_VERSION: packageJson.version,
 }
 

--- a/helpers.py
+++ b/helpers.py
@@ -3,8 +3,9 @@ import os
 from composio import Composio
 from composio_openai_agents import OpenAIAgentsProvider
 
-from dotenv import load_dotenv
-load_dotenv()
+from run_utils import _load_openswarm_dotenv
+
+_load_openswarm_dotenv()
 
 _composio_clients: dict[str, Composio] = {}
 

--- a/image_generation_agent/tools/CombineImages.py
+++ b/image_generation_agent/tools/CombineImages.py
@@ -4,12 +4,12 @@ from io import BytesIO
 from typing import Literal
 
 import os
-from dotenv import load_dotenv
 from openai import OpenAI
 from PIL import Image
 from pydantic import Field, field_validator, model_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 from shared_tools.openai_client_utils import get_openai_client
 
@@ -87,7 +87,7 @@ class CombineImages(BaseTool):
         return self
 
     def run(self) -> list:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         images_dir = get_images_dir(self.product_name)
         reference_images = [resolve_image_reference(self.product_name, ref)[0] for ref in self.image_refs]
 
@@ -222,4 +222,3 @@ if __name__ == "__main__":
         print(result)
     except Exception as exc:
         print(f"Image composition failed: {exc}")
-

--- a/image_generation_agent/tools/EditImages.py
+++ b/image_generation_agent/tools/EditImages.py
@@ -3,11 +3,11 @@
 from typing import Literal
 
 import os
-from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import Field, field_validator, model_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 from shared_tools.openai_client_utils import get_openai_client
 
@@ -77,7 +77,7 @@ class EditImages(BaseTool):
         return self
 
     def run(self) -> list:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         images_dir = get_images_dir(self.product_name)
         input_image, source = resolve_image_reference(self.product_name, self.input_image_ref)
 
@@ -211,4 +211,3 @@ if __name__ == "__main__":
         print(result)
     except Exception as exc:
         print(f"Image editing failed: {exc}")
-

--- a/image_generation_agent/tools/GenerateImages.py
+++ b/image_generation_agent/tools/GenerateImages.py
@@ -3,11 +3,11 @@
 from typing import Literal
 
 import os
-from dotenv import load_dotenv
 from openai import OpenAI
 from pydantic import Field, field_validator, model_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 from shared_tools.openai_client_utils import get_openai_client
 
@@ -71,7 +71,7 @@ class GenerateImages(BaseTool):
         return self
 
     def run(self) -> list:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         images_dir = get_images_dir(self.product_name)
 
         if self.model.startswith("gemini-"):
@@ -195,4 +195,3 @@ if __name__ == "__main__":
         print(result)
     except Exception as exc:
         print(f"Image generation failed: {exc}")
-

--- a/image_generation_agent/tools/RemoveBackground.py
+++ b/image_generation_agent/tools/RemoveBackground.py
@@ -3,7 +3,6 @@
 import io
 import os
 from pathlib import Path
-from dotenv import load_dotenv
 from urllib.parse import urlparse
 
 import fal_client
@@ -12,6 +11,7 @@ from PIL import Image
 from pydantic import Field, field_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 
 from .utils.image_io import (
@@ -52,7 +52,7 @@ class RemoveBackground(BaseTool):
         return value
 
     def run(self) -> list:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         api_key = os.getenv("FAL_KEY")
         if not api_key:
             raise ValueError(

--- a/onboard.py
+++ b/onboard.py
@@ -16,6 +16,8 @@ from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
 
+from run_utils import _openswarm_state_root
+
 try:
     import questionary
     from questionary import Choice, Style as QStyle
@@ -35,7 +37,7 @@ except ImportError:
 
 console = Console()
 
-ENV_PATH = Path(__file__).parent / ".env"
+ENV_PATH = _openswarm_state_root() / ".env"
 
 # ── questionary theme ─────────────────────────────────────────────────────────
 _QSTYLE = None
@@ -207,6 +209,7 @@ def _ask_confirm(message: str, default: bool = True) -> bool:
 
 
 def _write_env(updates: dict) -> None:
+    ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not ENV_PATH.exists():
         ENV_PATH.write_text("", encoding="utf-8")
     for key, value in updates.items():

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -1,10 +1,10 @@
 from agency_swarm import Agent, ModelSettings
 from openai.types.shared import Reasoning
-from dotenv import load_dotenv
 
 from config import get_default_model, is_openai_provider
+from run_utils import _load_openswarm_dotenv
 
-load_dotenv()
+_load_openswarm_dotenv()
 
 
 def create_orchestrator() -> Agent:

--- a/run_utils.py
+++ b/run_utils.py
@@ -34,12 +34,27 @@ _PRODUCT_WORDMARK_LINES = (
 )
 
 
+def _openswarm_state_root() -> Path:
+    override = os.getenv("OPENSWARM_STATE_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    if sys.platform == "win32":
+        return Path(os.getenv("APPDATA") or (Path.home() / "AppData" / "Roaming")) / "OpenSwarm"
+    return Path.home() / ".openswarm"
+
+
+def _load_openswarm_dotenv(*, override: bool = False) -> bool:
+    from dotenv import load_dotenv
+    return bool(load_dotenv(dotenv_path=_openswarm_state_root() / ".env", override=override))
+
+
 def _configure_product_env() -> None:
     os.environ.setdefault("AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION", "true")
     os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_LEFT", _PRODUCT_TUI_LOGO_LEFT)
     os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT", _PRODUCT_TUI_LOGO_RIGHT)
     os.environ.setdefault("AGENTSWARM_PRODUCT_WORDMARK_LINES", _PRODUCT_WORDMARK_LINES)
     os.environ.setdefault("AGENTSWARM_PRODUCT_ENABLE_ADDONS", "true")
+    os.environ["AGENTSWARM_PRODUCT_STATE_ROOT"] = str(_openswarm_state_root())
 
 
 def _preload_agentswarm_bin(repo: Path | None = None) -> None:
@@ -47,7 +62,7 @@ def _preload_agentswarm_bin(repo: Path | None = None) -> None:
     if "AGENTSWARM_BIN" in os.environ:
         return
 
-    roots = [repo] if repo else [Path.cwd(), Path(__file__).resolve().parent]
+    roots = [_openswarm_state_root()]
     seen: set[Path] = set()
 
     for root in roots:
@@ -413,8 +428,7 @@ def main() -> None:
     _preload_agentswarm_bin()
     _bootstrap()
 
-    from dotenv import load_dotenv
-    load_dotenv()
+    _load_openswarm_dotenv()
 
     os.environ.setdefault("PYTHONUTF8", "1")
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
@@ -479,7 +493,7 @@ def main() -> None:
             print("\nLaunching setup wizard…")
             from onboard import run_onboarding
             run_onboarding()
-            load_dotenv(override=True)
+            _load_openswarm_dotenv(override=True)
         else:
             break
 

--- a/run_utils.py
+++ b/run_utils.py
@@ -32,6 +32,16 @@ _PRODUCT_WORDMARK_LINES = (
     '"╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║",'
     '" ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
 )
+_PRODUCT_ADDONS = (
+    '[{"id":"search","title":"Web Search","keys":["SEARCH_API_KEY"]},'
+    '{"id":"anthropic","title":"Anthropic Claude","keys":["ANTHROPIC_API_KEY"],"excludeProviders":["anthropic"]},'
+    '{"id":"composio","title":"Composio","keys":["COMPOSIO_API_KEY","COMPOSIO_USER_ID"]},'
+    '{"id":"google","title":"Google Gemini","keys":["GOOGLE_API_KEY"],"excludeProviders":["google"]},'
+    '{"id":"fal","title":"Fal.ai","keys":["FAL_KEY"]},'
+    '{"id":"pexels","title":"Pexels","keys":["PEXELS_API_KEY"]},'
+    '{"id":"pixabay","title":"Pixabay","keys":["PIXABAY_API_KEY"]},'
+    '{"id":"unsplash","title":"Unsplash","keys":["UNSPLASH_ACCESS_KEY"]}]'
+)
 
 
 def _openswarm_state_root() -> Path:
@@ -53,7 +63,7 @@ def _configure_product_env() -> None:
     os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_LEFT", _PRODUCT_TUI_LOGO_LEFT)
     os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT", _PRODUCT_TUI_LOGO_RIGHT)
     os.environ.setdefault("AGENTSWARM_PRODUCT_WORDMARK_LINES", _PRODUCT_WORDMARK_LINES)
-    os.environ.setdefault("AGENTSWARM_PRODUCT_ENABLE_ADDONS", "true")
+    os.environ.setdefault("AGENTSWARM_PRODUCT_ADDONS", _PRODUCT_ADDONS)
     os.environ["AGENTSWARM_PRODUCT_STATE_ROOT"] = str(_openswarm_state_root())
 
 

--- a/scripts/smoke-bootstrap-onboard.py
+++ b/scripts/smoke-bootstrap-onboard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import os
 import sys
 import tempfile
@@ -190,6 +191,28 @@ def smoke_product_state_root_env() -> None:
                     raise RuntimeError("OpenSwarm did not load dotenv values from the fixed state root before caller cwd")
                 if os.environ.get("AGENTSWARM_BIN") != "/explicit/bin":
                     raise RuntimeError("OpenSwarm overwrote explicit AGENTSWARM_BIN from the fixed state root .env")
+                addons = json.loads(os.environ.get("AGENTSWARM_PRODUCT_ADDONS", "[]"))
+                if {addon.get("id") for addon in addons} != {
+                    "search",
+                    "anthropic",
+                    "composio",
+                    "google",
+                    "fal",
+                    "pexels",
+                    "pixabay",
+                    "unsplash",
+                }:
+                    raise RuntimeError("OpenSwarm Python path did not configure the generic add-ons JSON")
+                if "AGENTSWARM_PRODUCT_ENABLE_ADDONS" in os.environ:
+                    raise RuntimeError("OpenSwarm Python path still configured the legacy add-ons flag")
+                env.write_text(
+                    'AGENTSWARM_BIN="/tmp/test-agentswarm"\nOPENAI_API_KEY="state-openai-updated"\n',
+                    encoding="utf-8",
+                )
+                os.environ["OPENAI_API_KEY"] = "stale-openai"
+                run_utils._load_openswarm_dotenv(override=True)
+                if os.environ.get("OPENAI_API_KEY") != "state-openai-updated":
+                    raise RuntimeError("OpenSwarm post-onboarding dotenv refresh did not replace stale process values")
         finally:
             os.chdir(old_cwd)
             if old_state is None:

--- a/scripts/smoke-bootstrap-onboard.py
+++ b/scripts/smoke-bootstrap-onboard.py
@@ -48,9 +48,10 @@ def smoke_swarm_import_skips_bootstrap() -> None:
         "run_utils": module(
             "run_utils",
             _bootstrap=lambda: order.append("bootstrap"),
+            _openswarm_state_root=lambda: ROOT,
             _preload_agentswarm_bin=lambda: order.append("preload"),
         ),
-        "dotenv": module("dotenv", load_dotenv=lambda: order.append("dotenv")),
+        "dotenv": module("dotenv", load_dotenv=lambda *args, **kwargs: order.append("dotenv")),
         "agents": module(
             "agents",
             set_tracing_disabled=lambda _value: order.append("agents"),
@@ -142,6 +143,88 @@ def smoke_onboard_env_writes() -> None:
     missing = {key: value for key, value in expected.items() if values.get(key) != value}
     if missing:
         raise RuntimeError(f"onboarding did not write expected .env values: {missing}")
+
+
+def smoke_product_state_root_env() -> None:
+    sys.path.insert(0, str(ROOT))
+    try:
+        import run_utils
+    finally:
+        sys.path.pop(0)
+
+    with tempfile.TemporaryDirectory(prefix="openswarm-state-root-smoke-") as tmp:
+        root = Path(tmp).resolve()
+        env = root / ".env"
+        env.write_text(
+            'AGENTSWARM_BIN="/tmp/test-agentswarm"\nOPENAI_API_KEY="state-openai"\n',
+            encoding="utf-8",
+        )
+        caller = root / "caller"
+        caller.mkdir()
+        (caller / ".env").write_text(
+            'AGENTSWARM_BIN="/tmp/caller-agentswarm"\nOPENAI_API_KEY="caller-openai"\n',
+            encoding="utf-8",
+        )
+        old_state = os.environ.pop("AGENTSWARM_PRODUCT_STATE_ROOT", None)
+        old_bin = os.environ.pop("AGENTSWARM_BIN", None)
+        old_key = os.environ.pop("OPENAI_API_KEY", None)
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(caller)
+            with patch.dict(
+                os.environ,
+                {
+                    "OPENSWARM_STATE_ROOT": str(root),
+                    "AGENTSWARM_PRODUCT_STATE_ROOT": "/tmp/stale-openswarm-root",
+                    "AGENTSWARM_BIN": "/explicit/bin",
+                },
+                clear=False,
+            ):
+                run_utils._preload_agentswarm_bin()
+                run_utils._load_openswarm_dotenv()
+                run_utils._configure_product_env()
+
+                if os.environ.get("AGENTSWARM_PRODUCT_STATE_ROOT") != str(root):
+                    raise RuntimeError("OpenSwarm did not configure AGENTSWARM_PRODUCT_STATE_ROOT from OPENSWARM_STATE_ROOT")
+                if os.environ.get("OPENAI_API_KEY") != "state-openai":
+                    raise RuntimeError("OpenSwarm did not load dotenv values from the fixed state root before caller cwd")
+                if os.environ.get("AGENTSWARM_BIN") != "/explicit/bin":
+                    raise RuntimeError("OpenSwarm overwrote explicit AGENTSWARM_BIN from the fixed state root .env")
+        finally:
+            os.chdir(old_cwd)
+            if old_state is None:
+                os.environ.pop("AGENTSWARM_PRODUCT_STATE_ROOT", None)
+            else:
+                os.environ["AGENTSWARM_PRODUCT_STATE_ROOT"] = old_state
+            if old_bin is None:
+                os.environ.pop("AGENTSWARM_BIN", None)
+            else:
+                os.environ["AGENTSWARM_BIN"] = old_bin
+            if old_key is None:
+                os.environ.pop("OPENAI_API_KEY", None)
+            else:
+                os.environ["OPENAI_API_KEY"] = old_key
+
+    with tempfile.TemporaryDirectory(prefix="openswarm-state-root-smoke-") as tmp:
+        base = Path(tmp).resolve()
+        root = base / "state"
+        caller = base / "caller"
+        caller.mkdir(parents=True)
+        (caller / ".env").write_text('AGENTSWARM_BIN="/tmp/caller-agentswarm"\n', encoding="utf-8")
+        old_bin = os.environ.pop("AGENTSWARM_BIN", None)
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(caller)
+            with patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(root)}, clear=False):
+                run_utils._preload_agentswarm_bin(repo=caller)
+                if "AGENTSWARM_BIN" in os.environ:
+                    raise RuntimeError("OpenSwarm preloaded AGENTSWARM_BIN outside the fixed state root")
+        finally:
+            os.chdir(old_cwd)
+            if old_bin is None:
+                os.environ.pop("AGENTSWARM_BIN", None)
+            else:
+                os.environ["AGENTSWARM_BIN"] = old_bin
 
 
 def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
@@ -290,6 +373,7 @@ def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
 def main() -> int:
     smoke_swarm_import_skips_bootstrap()
     smoke_onboard_env_writes()
+    smoke_product_state_root_env()
     smoke_bootstrap_node_setup_installs_slides_dependencies()
     print("OpenSwarm import bootstrap and onboarding smoke passed")
     return 0

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -103,7 +103,7 @@ function load(opts) {
   assert.notEqual(startup, -1, 'launcher startup block not found')
   const script = new vm.Script(
     `${source.slice(start, startup)}
-module.exports = { getBinaryNames, isMuslLinux, shouldUseDependencyBinary, ensureCustomBinary }`,
+module.exports = { downstreamEnv, getBinaryNames, isMuslLinux, shouldUseDependencyBinary, ensureCustomBinary }`,
     { filename: launcher },
   )
   script.runInNewContext(context)
@@ -112,6 +112,23 @@ module.exports = { getBinaryNames, isMuslLinux, shouldUseDependencyBinary, ensur
     api: context.module.exports,
     requests,
   }
+}
+
+function assertProductAddons(api) {
+  assert.ok(api.downstreamEnv, 'downstreamEnv export not available')
+  assert.ok(api.downstreamEnv.AGENTSWARM_PRODUCT_ADDONS, 'AGENTSWARM_PRODUCT_ADDONS not set')
+
+  const addons = JSON.parse(api.downstreamEnv.AGENTSWARM_PRODUCT_ADDONS)
+  assert.deepEqual(addons, [
+    { id: 'search', title: 'Web Search', keys: ['SEARCH_API_KEY'] },
+    { id: 'anthropic', title: 'Anthropic Claude', keys: ['ANTHROPIC_API_KEY'], excludeProviders: ['anthropic'] },
+    { id: 'composio', title: 'Composio', keys: ['COMPOSIO_API_KEY', 'COMPOSIO_USER_ID'] },
+    { id: 'google', title: 'Google Gemini', keys: ['GOOGLE_API_KEY'], excludeProviders: ['google'] },
+    { id: 'fal', title: 'Fal.ai', keys: ['FAL_KEY'] },
+    { id: 'pexels', title: 'Pexels', keys: ['PEXELS_API_KEY'] },
+    { id: 'pixabay', title: 'Pixabay', keys: ['PIXABAY_API_KEY'] },
+    { id: 'unsplash', title: 'Unsplash', keys: ['UNSPLASH_ACCESS_KEY'] },
+  ])
 }
 
 async function main() {
@@ -124,6 +141,7 @@ async function main() {
   assert.equal(musl.api.shouldUseDependencyBinary(), true)
   assert.equal(await musl.api.ensureCustomBinary(), null)
   assert.deepEqual(musl.requests, [])
+  assertProductAddons(musl.api)
 
   const explicit = load({
     platform: 'linux',

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -76,6 +76,7 @@ function load(opts) {
     https: createClient(requests),
     os: {
       arch: () => opts.arch,
+      homedir: () => opts.homedir || '/home/tester',
     },
     path,
     'child_process': child,
@@ -103,7 +104,7 @@ function load(opts) {
   assert.notEqual(startup, -1, 'launcher startup block not found')
   const script = new vm.Script(
     `${source.slice(start, startup)}
-module.exports = { downstreamEnv, getBinaryNames, isMuslLinux, shouldUseDependencyBinary, ensureCustomBinary }`,
+module.exports = { downstreamEnv, getBinaryNames, isMuslLinux, resolveStateRoot, shouldUseDependencyBinary, ensureCustomBinary }`,
     { filename: launcher },
   )
   script.runInNewContext(context)
@@ -131,6 +132,42 @@ function assertProductAddons(api) {
   ])
 }
 
+function assertStateRoot() {
+  const linux = load({
+    platform: 'linux',
+    arch: 'x64',
+    homedir: '/home/tester',
+  })
+  assert.equal(linux.api.resolveStateRoot(), path.join('/home/tester', '.openswarm'))
+  assert.equal(linux.api.downstreamEnv.AGENTSWARM_PRODUCT_STATE_ROOT, path.join('/home/tester', '.openswarm'))
+
+  const darwin = load({
+    platform: 'darwin',
+    arch: 'arm64',
+    homedir: '/Users/tester',
+  })
+  assert.equal(darwin.api.resolveStateRoot(), path.join('/Users/tester', '.openswarm'))
+
+  const windows = load({
+    platform: 'win32',
+    arch: 'x64',
+    homedir: 'C:\\Users\\tester',
+    env: {
+      APPDATA: 'C:\\Users\\tester\\AppData\\Roaming',
+    },
+  })
+  assert.equal(windows.api.resolveStateRoot(), path.join('C:\\Users\\tester\\AppData\\Roaming', 'OpenSwarm'))
+
+  const explicit = load({
+    platform: 'linux',
+    arch: 'x64',
+    env: {
+      OPENSWARM_STATE_ROOT: '/tmp/openswarm-state',
+    },
+  })
+  assert.equal(explicit.api.resolveStateRoot(), path.resolve('/tmp/openswarm-state'))
+}
+
 async function main() {
   const musl = load({
     platform: 'linux',
@@ -142,6 +179,7 @@ async function main() {
   assert.equal(await musl.api.ensureCustomBinary(), null)
   assert.deepEqual(musl.requests, [])
   assertProductAddons(musl.api)
+  assertStateRoot()
 
   const explicit = load({
     platform: 'linux',

--- a/server.py
+++ b/server.py
@@ -1,9 +1,10 @@
 # FastAPI entry point — run with: python server.py
 
 import logging
-from dotenv import load_dotenv
 
-load_dotenv()
+from run_utils import _load_openswarm_dotenv
+
+_load_openswarm_dotenv()
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/shared_tools/model_availability.py
+++ b/shared_tools/model_availability.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
-from dotenv import load_dotenv
+from run_utils import _load_openswarm_dotenv
 
 from shared_tools.openai_client_utils import get_caller_openai_credentials
 
 
 def _refresh_runtime_env() -> None:
     """Reload add-on keys written through the TUI into the running process."""
-    load_dotenv(dotenv_path=Path.cwd() / ".env", override=True)
-    load_dotenv(override=True)
+    _load_openswarm_dotenv()
 
 
 def _configured(value: bool) -> str:

--- a/slides_agent/tools/GenerateImage.py
+++ b/slides_agent/tools/GenerateImage.py
@@ -5,9 +5,9 @@ import asyncio
 import inspect
 
 import os
-from dotenv import load_dotenv
 from agency_swarm.tools import BaseTool, LoadFileAttachment
 from pydantic import Field
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 
 
@@ -53,7 +53,7 @@ class GenerateImage(BaseTool):
 
     def run(self) -> str:
         """Generate image and save to the project's assets folder."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         from .slide_file_utils import get_project_dir
         try:
             full_prompt = self.prompt

--- a/slides_agent/tools/ImageSearch.py
+++ b/slides_agent/tools/ImageSearch.py
@@ -7,9 +7,9 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import os
-from dotenv import load_dotenv
 from agency_swarm.tools import BaseTool
 from pydantic import Field
+from run_utils import _load_openswarm_dotenv
 
 
 class ImageSearch(BaseTool):
@@ -32,7 +32,7 @@ class ImageSearch(BaseTool):
     )
 
     def run(self) -> str:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv()
         providers = [p.lower() for p in (self.providers or ["unsplash", "pexels", "pixabay"])]
         results = []
         warnings = []

--- a/slides_agent/tools/ImageSearch.py
+++ b/slides_agent/tools/ImageSearch.py
@@ -32,7 +32,7 @@ class ImageSearch(BaseTool):
     )
 
     def run(self) -> str:
-        _load_openswarm_dotenv()
+        _load_openswarm_dotenv(override=True)
         providers = [p.lower() for p in (self.providers or ["unsplash", "pexels", "pixabay"])]
         results = []
         warnings = []

--- a/slides_agent/tools/InsertNewSlides.py
+++ b/slides_agent/tools/InsertNewSlides.py
@@ -14,12 +14,12 @@ from types import SimpleNamespace
 from typing import Literal
 
 import os
-from dotenv import load_dotenv
 from agency_swarm import Agent, ModelSettings, Reasoning
 from agency_swarm.tools import BaseTool
 from openai import AsyncOpenAI
 from agents.extensions.models.litellm_model import LitellmModel
 from pydantic import BaseModel, Field, ValidationError
+from run_utils import _load_openswarm_dotenv
 
 from .slide_file_utils import (
     apply_renames,
@@ -422,7 +422,7 @@ class InsertNewSlides(BaseTool):
 
     def run(self):
         """Insert blank placeholders and return a planning-oriented response."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         project_dir = get_project_dir(self.project_name)
         project_dir.mkdir(parents=True, exist_ok=True)
 

--- a/slides_agent/tools/ModifySlide.py
+++ b/slides_agent/tools/ModifySlide.py
@@ -11,7 +11,6 @@ import base64
 import mimetypes
 import os
 import re
-from dotenv import load_dotenv
 import tempfile
 import threading
 from datetime import datetime, timezone
@@ -23,6 +22,7 @@ from agency_swarm.tools import BaseTool, ToolOutputText, tool_output_image_from_
 from agents.extensions.models.litellm_model import LitellmModel
 from openai import AsyncOpenAI
 from pydantic import Field
+from run_utils import _load_openswarm_dotenv
 
 from .slide_file_utils import get_project_dir
 from .slide_html_utils import (
@@ -534,7 +534,7 @@ class ModifySlide(BaseTool):
     save_as_template_name: str | None = Field(default=None, description="Optional display name for saved template")
 
     async def run(self):
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         project_dir = get_project_dir(self.project_name)
         if not project_dir.exists():
             return f"Project not found: {project_dir}"

--- a/swarm.py
+++ b/swarm.py
@@ -1,6 +1,6 @@
 import os
 
-from run_utils import _bootstrap, _preload_agentswarm_bin
+from run_utils import _bootstrap, _openswarm_state_root, _preload_agentswarm_bin
 
 _RUNTIME_CONFIGURED = False
 
@@ -19,7 +19,7 @@ def _configure_runtime() -> None:
     )
     from patches.patch_utf8_file_reads import apply_utf8_file_read_patch
 
-    load_dotenv()
+    load_dotenv(dotenv_path=_openswarm_state_root() / ".env")
 
     apply_utf8_file_read_patch()
     apply_dual_comms_patch()

--- a/video_generation_agent/tools/CombineImages.py
+++ b/video_generation_agent/tools/CombineImages.py
@@ -5,12 +5,12 @@ from typing import Literal
 from pathlib import Path
 
 import os
-from dotenv import load_dotenv
 from google import genai
 from PIL import Image
 from pydantic import Field, field_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 
 from .utils.image_utils import (
@@ -92,7 +92,7 @@ class CombineImages(BaseTool):
 
     async def run(self) -> list:
         """Combine images using the Gemini API."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:
             raise ValueError(

--- a/video_generation_agent/tools/EditImage.py
+++ b/video_generation_agent/tools/EditImage.py
@@ -3,12 +3,12 @@
 import asyncio
 import os
 from typing import Literal
-from dotenv import load_dotenv
 
 from google import genai
 from pydantic import Field, field_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 
 from .utils.image_utils import (
@@ -85,7 +85,7 @@ class EditImage(BaseTool):
 
     async def run(self) -> list:
         """Edit an image using the Gemini API."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:
             raise ValueError(

--- a/video_generation_agent/tools/EditVideoContent.py
+++ b/video_generation_agent/tools/EditVideoContent.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 import re
-from dotenv import load_dotenv
 import cv2
 import httpx
 from typing import Annotated, Literal, Optional, Union
@@ -15,6 +14,7 @@ from google.genai import types
 from PIL import Image
 
 from agency_swarm import BaseTool, ToolOutputText
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import video_model_availability_message
 
 from .utils.video_utils import (
@@ -164,7 +164,7 @@ class EditVideoContent(BaseTool):
         return _ensure_not_blank(value, "name")
 
     async def run(self) -> list:
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         if self.mode.action == "remix":
             return await self._run_remix(self.mode)
         if self.mode.action == "extend":

--- a/video_generation_agent/tools/GenerateImage.py
+++ b/video_generation_agent/tools/GenerateImage.py
@@ -3,12 +3,12 @@
 import asyncio
 import os
 from typing import Literal
-from dotenv import load_dotenv
 
 from google import genai
 from pydantic import Field, field_validator
 
 from agency_swarm import BaseTool
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import image_model_availability_message
 
 
@@ -77,7 +77,7 @@ class GenerateImage(BaseTool):
 
     async def run(self) -> list:
         """Generate images using the Gemini API."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:
             raise ValueError(

--- a/video_generation_agent/tools/GenerateVideo.py
+++ b/video_generation_agent/tools/GenerateVideo.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 import os
 import re
-from dotenv import load_dotenv
 import mimetypes
 from pathlib import Path
 from urllib.parse import urlparse
@@ -19,6 +18,7 @@ from PIL import Image as PILImage
 from io import BytesIO
 
 from agency_swarm import BaseTool, ToolOutputText
+from run_utils import _load_openswarm_dotenv
 from shared_tools.model_availability import video_model_availability_message
 from shared_tools.openai_client_utils import get_openai_client
 
@@ -168,7 +168,7 @@ class GenerateVideo(BaseTool):
 
     async def run(self) -> list:
         """Generate a marketing video using the chosen model."""
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         if is_seedance_model(self.model):
             return await self._generate_with_seedance(self.model)
 

--- a/virtual_assistant/tools/ProductSearch.py
+++ b/virtual_assistant/tools/ProductSearch.py
@@ -4,7 +4,7 @@ from pydantic import Field
 import json
 
 import os
-from dotenv import load_dotenv
+from run_utils import _load_openswarm_dotenv
 
 
 class ProductSearch(BaseTool):
@@ -72,7 +72,7 @@ class ProductSearch(BaseTool):
     )
     
     def run(self):
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         try:
             import requests
             
@@ -253,4 +253,3 @@ if __name__ == "__main__":
     print("=" * 60)
     print("Tests completed!")
     print("=" * 60)
-

--- a/virtual_assistant/tools/ScholarSearch.py
+++ b/virtual_assistant/tools/ScholarSearch.py
@@ -4,7 +4,7 @@ from pydantic import Field
 import json
 
 import os
-from dotenv import load_dotenv
+from run_utils import _load_openswarm_dotenv
 
 
 class ScholarSearch(BaseTool):
@@ -47,7 +47,7 @@ class ScholarSearch(BaseTool):
     )
     
     def run(self):
-        load_dotenv(override=True)
+        _load_openswarm_dotenv(override=True)
         try:
             import requests
             
@@ -215,4 +215,3 @@ if __name__ == "__main__":
     print("=" * 60)
     print("Tests completed!")
     print("=" * 60)
-

--- a/virtual_assistant/virtual_assistant.py
+++ b/virtual_assistant/virtual_assistant.py
@@ -5,12 +5,12 @@ from agency_swarm.tools import (
     IPythonInterpreter,
 )
 from openai.types.shared import Reasoning
-from dotenv import load_dotenv
 
 from config import get_default_model, is_openai_provider
+from run_utils import _load_openswarm_dotenv
 from shared_tools import CopyFile, ExecuteTool, FindTools, ManageConnections, SearchTools
 
-load_dotenv()
+_load_openswarm_dotenv()
 
 # Class-level rename — idempotent, safe to run once at import time.
 IPythonInterpreter.__name__ = "ProgrammaticToolCalling"


### PR DESCRIPTION
## Summary

- move OpenSwarm's concrete add-ons list into the `openswarm` launcher via `AGENTSWARM_PRODUCT_ADDONS`
- align the Python startup path with the same generic add-ons config and remove the legacy add-ons enable flag
- store OpenSwarm runtime state under a fixed user root while keeping the project, `.venv`, logs, and `.env` in predictable locations
- keep generic AgentSwarm behavior in VRSEN/agentswarm-cli#235 and use OpenSwarm as the downstream product configuration

Fixes #49.

## Dependency

Depends on VRSEN/agentswarm-cli#235 before production release. OpenSwarm now passes its concrete add-ons and fixed product state root through the generic AgentSwarm product configuration.

## Evidence

- `python3 -m py_compile run_utils.py scripts/smoke-bootstrap-onboard.py slides_agent/tools/ImageSearch.py`
- `python3 scripts/smoke-bootstrap-onboard.py`
- `node scripts/smoke-openswarm-launcher.js`
- `git diff --check`
- local package proof: `npm install`, `npm exec`, and `npx` against the final local `1.0.1-rc.8` tarball all returned `1.0.1-rc.8`
- local TUI package proof: final local `1.0.1-rc.8` package passed `/agents` and `/models`
- baseline package proof: GitHub release `v1.0.1-rc.7` package passed `/agents` and `/models`
- live package proof: final local `1.0.1-rc.8` package passed prompt and handoff smokes with Anthropic auth from the fixed OpenSwarm state root
- local Codex review on the latest incremental diff: no discrete regression found

## Manual QA

Human QA approved `/addons` on the local `1.0.1-rc.8` build.
