### PR TITLE
ci: pass telemetry secrets to OpenSwarm TUI build

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -158,6 +158,7 @@ jobs:
             asset: agentswarm-windows-arm64.exe
 
     runs-on: ${{ matrix.os }}
+    environment: ${{ needs.prepare.outputs.is_prerelease == 'true' && 'dev' || 'prod' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -173,11 +174,9 @@ jobs:
         shell: bash
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: |
           set -euo pipefail
           test -n "$POSTHOG_API_KEY"
-          test -n "$POSTHOG_HOST"
 
       - name: Install dependencies
         working-directory: agentswarm-cli

--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -170,7 +170,8 @@ jobs:
         with:
           bun-version: "1.3.13"
 
-      - name: Validate product telemetry secrets
+      - name: Validate official product telemetry secrets
+        if: github.repository == 'VRSEN/OpenSwarm'
         shell: bash
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}

--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -169,6 +169,16 @@ jobs:
         with:
           bun-version: "1.3.13"
 
+      - name: Validate product telemetry secrets
+        shell: bash
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+        run: |
+          set -euo pipefail
+          test -n "$POSTHOG_API_KEY"
+          test -n "$POSTHOG_HOST"
+
       - name: Install dependencies
         working-directory: agentswarm-cli
         run: bun install
@@ -179,6 +189,8 @@ jobs:
           BUILD_ALL: ${{ matrix.build_all || false }}
           BASELINE: ${{ matrix.baseline }}
           OPENCODE_CHANNEL: ${{ needs.prepare.outputs.npm_tag }}
+          AGENTSWARM_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          AGENTSWARM_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
           AGENTSWARM_PRODUCT_COMMAND: openswarm
           AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"


### PR DESCRIPTION
## Summary
- select the OpenSwarm GitHub environment for TUI binary builds: `dev` for prereleases, `prod` for stable releases
- require the existing environment-level `POSTHOG_API_KEY` only for official `VRSEN/OpenSwarm` builds
- pass the PostHog key, plus optional `POSTHOG_HOST` if present, into the checked-out AgentSwarm CLI build as `AGENTSWARM_POSTHOG_*`

## Notes
- Official OpenSwarm releases use the existing `dev` and `prod` environment secrets.
- Forked OpenSwarm builds do not need PostHog secrets; they build without telemetry unless the fork owner provides their own key.
- `POSTHOG_HOST` is optional; AgentSwarm CLI defaults to the PostHog US ingestion host when it is not provided.
- Telemetry only takes effect once `AGENTSWARM_CLI_VERSION` points to an AgentSwarm CLI release that includes the telemetry build-time injection.
