### PR TITLE
Use product config for OpenSwarm npm packages

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -149,7 +149,7 @@ jobs:
             arch: x64
             baseline: true
             build_all: true
-            asset: agentswarm-windows-x64-baseline.exe
+            asset: build-all-assets
           - os: windows-11-arm
             platform: windows
             arch: arm64
@@ -160,6 +160,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: ${{ needs.prepare.outputs.is_prerelease == 'true' && 'dev' || 'prod' }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          path: openswarm
+
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
@@ -183,6 +187,12 @@ jobs:
         working-directory: agentswarm-cli
         run: bun install
 
+      - name: Load OpenSwarm product env
+        working-directory: openswarm
+        env:
+          OPENSWARM_PRODUCT_VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: node -e "const fs=require('fs');const cp=require('child_process');fs.appendFileSync(process.env.GITHUB_ENV,cp.execFileSync(process.execPath,['scripts/write-product-env.mjs'],{encoding:'utf8'}));"
+
       - name: Build binary
         working-directory: agentswarm-cli/packages/opencode
         env:
@@ -191,24 +201,6 @@ jobs:
           OPENCODE_CHANNEL: ${{ needs.prepare.outputs.npm_tag }}
           AGENTSWARM_POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           AGENTSWARM_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
-          AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
-          AGENTSWARM_PRODUCT_COMMAND: openswarm
-          AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_RELEASE_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_DOCS_URL: https://github.com/VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_ISSUE_URL: https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml
-          AGENTSWARM_PRODUCT_MDNS_DOMAIN: openswarm.local
-          AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
-          AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py
-          AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION: "true"
-          AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: '["                                    "," ██████╗ ██████╗ ███████╗███╗   ██╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║","╚██████╔╝██║     ███████╗██║ ╚████║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝"]'
-          AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: '["","███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","╚════██║██║███╗██║██╔══██║██╔══██╗██║╚██╔╝██║","███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║","╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_WORDMARK_LINES: '[""," ██████╗ ██████╗ ███████╗███╗   ██╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║ ██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║ ███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║ ╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║","╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: standalone
-          AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true"
-          AGENTSWARM_PRODUCT_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           node -e "const cp=require('child_process');const all=process.env.BUILD_ALL==='true';const args=all?['run','script/build.ts']:['run','script/build.ts','--single','--skip-install',...(process.env.BASELINE==='true'?['--baseline']:[])];cp.execFileSync('bun',args,{stdio:'inherit'});"
 
@@ -216,6 +208,13 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
+          if [[ "${{ matrix.build_all || false }}" == "true" ]]; then
+            cp agentswarm-cli/packages/opencode/dist/agentswarm-cli-linux-arm64-musl/bin/agentswarm agentswarm-linux-arm64-musl
+            cp agentswarm-cli/packages/opencode/dist/agentswarm-cli-linux-x64-musl/bin/agentswarm agentswarm-linux-x64-musl
+            cp agentswarm-cli/packages/opencode/dist/agentswarm-cli-linux-x64-baseline-musl/bin/agentswarm agentswarm-linux-x64-baseline-musl
+            cp agentswarm-cli/packages/opencode/dist/agentswarm-cli-windows-x64-baseline/bin/agentswarm.exe agentswarm-windows-x64-baseline.exe
+            exit 0
+          fi
           binary="agentswarm"
           if [[ "${{ matrix.platform }}" == "windows" ]]; then
             binary="agentswarm.exe"
@@ -231,10 +230,23 @@ jobs:
             ${{ matrix.asset }}
 
       - name: Upload artifact
+        if: ${{ matrix.build_all != true }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
+          if-no-files-found: error
+
+      - name: Upload build-all artifacts
+        if: ${{ matrix.build_all == true }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-all-assets
+          path: |
+            agentswarm-linux-arm64-musl
+            agentswarm-linux-x64-musl
+            agentswarm-linux-x64-baseline-musl
+            agentswarm-windows-x64-baseline.exe
           if-no-files-found: error
 
   release:
@@ -349,8 +361,11 @@ jobs:
             agentswarm-darwin-x64
             agentswarm-darwin-x64-baseline
             agentswarm-linux-arm64
+            agentswarm-linux-arm64-musl
             agentswarm-linux-x64
             agentswarm-linux-x64-baseline
+            agentswarm-linux-x64-baseline-musl
+            agentswarm-linux-x64-musl
             agentswarm-windows-arm64.exe
             agentswarm-windows-x64.exe
             agentswarm-windows-x64-baseline.exe
@@ -365,6 +380,37 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Download platform release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" --dir dist --clobber
+
+      - name: Pack platform npm packages
+        run: node scripts/package-platform-binaries.mjs dist platform-packages
+
+      - name: Publish platform npm packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t packages < <(find platform-packages -maxdepth 1 -name '*.tgz' -type f | sort)
+          if (( ${#packages[@]} != 12 )); then
+            echo "Expected 12 OpenSwarm platform packages, got ${#packages[@]}." >&2
+            exit 1
+          fi
+          for package in "${packages[@]}"; do
+            pkg_id="$(tar -xOf "$package" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); console.log(pkg.name+'@'+pkg.version)")"
+            if npm view "$pkg_id" version >/dev/null 2>&1; then
+              echo "Skipping $pkg_id; already published."
+              continue
+            fi
+            npm publish "$package" --access public --tag "$NPM_TAG"
+          done
 
       - name: Publish npm package
         run: npm publish --access public --tag "$NPM_TAG"

--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - '.github/workflows/live-run-mode-smoke.yml'
       - 'bin/openswarm'
+      - 'openswarm.config.mjs'
       - 'package-lock.json'
       - 'package.json'
       - 'pyproject.toml'
+      - 'scripts/write-product-env.mjs'
       - 'scripts/smoke-run-mode.py'
       - 'swarm.py'
       - '*_agent/**'
@@ -40,29 +42,15 @@ jobs:
       - name: Resolve OpenSwarm package version
         id: openswarm
         run: node -e "console.log('version=' + require('./package.json').version)" >> "$GITHUB_OUTPUT"
+      - name: Load OpenSwarm product env
+        env:
+          OPENSWARM_PRODUCT_VERSION: ${{ steps.openswarm.outputs.version }}
+        run: node -e "const fs=require('fs');const cp=require('child_process');fs.appendFileSync(process.env.GITHUB_ENV,cp.execFileSync(process.execPath,['scripts/write-product-env.mjs'],{encoding:'utf8'}));"
       - name: Build local OpenSwarm TUI
         shell: bash
         working-directory: agentswarm-cli
         env:
           OPENCODE_CHANNEL: rc
-          AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
-          AGENTSWARM_PRODUCT_COMMAND: openswarm
-          AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_RELEASE_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_DOCS_URL: https://github.com/VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_ISSUE_URL: https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml
-          AGENTSWARM_PRODUCT_MDNS_DOMAIN: openswarm.local
-          AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
-          AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py
-          AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION: "true"
-          AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: '["                                    "," ██████╗ ██████╗ ███████╗███╗   ██╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║","╚██████╔╝██║     ███████╗██║ ╚████║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝"]'
-          AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: '["","███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","╚════██║██║███╗██║██╔══██║██╔══██╗██║╚██╔╝██║","███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║","╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_WORDMARK_LINES: '[""," ██████╗ ██████╗ ███████╗███╗   ██╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║ ██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║ ███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║ ╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║","╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: standalone
-          AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true"
-          AGENTSWARM_PRODUCT_VERSION: ${{ steps.openswarm.outputs.version }}
         run: |
           bun install
           cd packages/opencode

--- a/.github/workflows/publish-npm-on-release.yml
+++ b/.github/workflows/publish-npm-on-release.yml
@@ -76,8 +76,16 @@ jobs:
           required_assets=(
             agentswarm-darwin-arm64
             agentswarm-darwin-x64
+            agentswarm-darwin-x64-baseline
+            agentswarm-linux-arm64
+            agentswarm-linux-arm64-musl
             agentswarm-linux-x64
+            agentswarm-linux-x64-baseline
+            agentswarm-linux-x64-baseline-musl
+            agentswarm-linux-x64-musl
+            agentswarm-windows-arm64.exe
             agentswarm-windows-x64.exe
+            agentswarm-windows-x64-baseline.exe
           )
 
           for required in "${required_assets[@]}"; do
@@ -91,6 +99,37 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Download platform release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$RELEASE_TAG" --dir dist --clobber
+
+      - name: Pack platform npm packages
+        run: node scripts/package-platform-binaries.mjs dist platform-packages
+
+      - name: Publish platform npm packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t packages < <(find platform-packages -maxdepth 1 -name '*.tgz' -type f | sort)
+          if (( ${#packages[@]} != 12 )); then
+            echo "Expected 12 OpenSwarm platform packages, got ${#packages[@]}." >&2
+            exit 1
+          fi
+          for package in "${packages[@]}"; do
+            pkg_id="$(tar -xOf "$package" package/package.json | node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); console.log(pkg.name+'@'+pkg.version)")"
+            if npm view "$pkg_id" version >/dev/null 2>&1; then
+              echo "Skipping $pkg_id; already published."
+              continue
+            fi
+            npm publish "$package" --access public --tag "$NPM_TAG"
+          done
 
       - name: Publish npm package
         run: npm publish --access public --tag "$NPM_TAG"

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -6,8 +6,12 @@ on:
       - '.github/workflows/build-tui.yml'
       - '.github/workflows/test-mac.yml'
       - 'bin/openswarm'
+      - 'openswarm.config.mjs'
       - 'package.json'
+      - 'package-lock.json'
       - 'scripts/smoke-openswarm-launcher.js'
+      - 'scripts/package-platform-binaries.mjs'
+      - 'scripts/write-product-env.mjs'
 
 jobs:
   test:
@@ -19,6 +23,8 @@ jobs:
           node-version: 20
       - name: Smoke-test launcher platform resolution
         run: node scripts/smoke-openswarm-launcher.js
+      - name: Load OpenSwarm product env
+        run: node -e "const fs=require('fs');const cp=require('child_process');process.env.OPENSWARM_PRODUCT_VERSION=require('./package.json').version;fs.appendFileSync(process.env.GITHUB_ENV,cp.execFileSync(process.execPath,['scripts/write-product-env.mjs'],{encoding:'utf8'}));"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -35,57 +41,20 @@ jobs:
         working-directory: agentswarm-cli
         env:
           OPENCODE_CHANNEL: rc
-          AGENTSWARM_PRODUCT_DISPLAY_NAME: OpenSwarm
-          AGENTSWARM_PRODUCT_COMMAND: openswarm
-          AGENTSWARM_PRODUCT_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: "@vrsen/openswarm"
-          AGENTSWARM_PRODUCT_RELEASE_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_DOCS_URL: https://github.com/VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_ISSUE_URL: https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml
-          AGENTSWARM_PRODUCT_MDNS_DOMAIN: openswarm.local
-          AGENTSWARM_PRODUCT_STARTER_REPO: VRSEN/OpenSwarm
-          AGENTSWARM_PRODUCT_STARTER_FOLDER: openswarm
-          AGENTSWARM_PRODUCT_ENTRY_FILES: swarm.py
-          AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: '["                                    "," ██████╗ ██████╗ ███████╗███╗   ██╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║","╚██████╔╝██║     ███████╗██║ ╚████║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝"]'
-          AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: '["","███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","╚════██║██║███╗██║██╔══██║██╔══██╗██║╚██╔╝██║","███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║","╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_WORDMARK_LINES: '[""," ██████╗ ██████╗ ███████╗███╗   ██╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗","██╔═══██╗██╔══██╗██╔════╝████╗  ██║ ██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║","██║   ██║██████╔╝█████╗  ██╔██╗ ██║ ███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║","██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║ ╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║","╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║"," ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-          AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: standalone
-          AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true"
-          AGENTSWARM_PRODUCT_VERSION: 1.0.1-rc.7
         run: |
           bun install
           cd packages/opencode
           bun run script/build.ts --single --skip-install
-          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "1.0.1-rc.7"
+          test "$(./dist/agentswarm-cli-darwin-arm64/bin/agentswarm --version)" = "$AGENTSWARM_PRODUCT_VERSION"
       - name: Test startup
         shell: bash
         run: |
           python - <<'EOF'
-          import functools
-          import http.server
           import os
           import pathlib
-          import platform
           import subprocess
           import sys
           import tempfile
-          import threading
-
-          class QuietHandler(http.server.SimpleHTTPRequestHandler):
-              def log_message(self, format, *args):
-                  pass
-
-          def resolve_binary_name():
-              machine = platform.machine().lower()
-              arch = "arm64" if machine in ("arm64", "aarch64") else "x64"
-              return f"agentswarm-darwin-{arch}"
-
-          def start_server(directory):
-              handler = functools.partial(QuietHandler, directory=str(directory))
-              server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
-              thread = threading.Thread(target=server.serve_forever, daemon=True)
-              thread.start()
-              return server, thread
 
           def run_version(binary, cwd, env):
               return subprocess.run(
@@ -107,14 +76,36 @@ jobs:
                       return candidate
               return None
 
+          def install_platform_package(root, repo):
+              binary = repo / "agentswarm-cli" / "packages" / "opencode" / "dist" / "agentswarm-cli-darwin-arm64" / "bin" / "agentswarm"
+              if not binary.exists():
+                  raise RuntimeError(f"built OpenSwarm binary is missing at {binary}")
+              target = (
+                  root
+                  / "node_modules"
+                  / "@vrsen"
+                  / "openswarm"
+                  / "node_modules"
+                  / "@vrsen"
+                  / "openswarm-cli-darwin-arm64"
+                  / "bin"
+              )
+              target.mkdir(parents=True, exist_ok=True)
+              installed = target / "agentswarm"
+              installed.write_bytes(binary.read_bytes())
+              installed.chmod(0o755)
+
           repo = pathlib.Path.cwd()
           root = pathlib.Path(tempfile.mkdtemp(prefix="openswarm-smoke-"))
-          release_dir = root / "release"
-          release_dir.mkdir()
           env = {**os.environ, "OPENSWARM_DEMO_SILENCE_CONSOLE": "0"}
-          binary_name = resolve_binary_name()
-          server, thread = start_server(release_dir)
-          base_url = f"http://127.0.0.1:{server.server_port}"
+          package_version = subprocess.run(
+              ["node", "-p", "require('./package.json').version"],
+              cwd=repo,
+              check=True,
+              capture_output=True,
+              text=True,
+              env=env,
+          ).stdout.strip()
 
           pack = subprocess.run(["npm", "pack"], cwd=repo, check=True, capture_output=True, text=True, env=env)
           tarball = repo / next(line.strip() for line in reversed(pack.stdout.splitlines()) if line.strip())
@@ -141,27 +132,11 @@ jobs:
           else:
               listing = None
 
-          missing_runs = []
-          invalid_runs = []
-          success_runs = []
+          version_runs = []
           if binary is not None:
-              missing_env = {**env, "OPENSWARM_TUI_URL": f"{base_url}/missing/{binary_name}"}
-              missing_runs = [run_version(binary, root, missing_env) for _ in range(2)]
-
-              invalid_binary = release_dir / binary_name
-              invalid_binary.write_text("#!/bin/sh\nkill -9 $$\n", encoding="utf-8")
-              invalid_binary.chmod(0o755)
-              invalid_env = {**env, "OPENSWARM_TUI_URL": f"{base_url}/{binary_name}"}
-              invalid_runs = [run_version(binary, root, invalid_env) for _ in range(2)]
-
-              fake_binary = release_dir / binary_name
-              fake_binary.write_text("#!/bin/sh\nprintf '9.9.9-custom\\n'\n", encoding="utf-8")
-              fake_binary.chmod(0o755)
-              success_env = {**env, "OPENSWARM_TUI_URL": f"{base_url}/{binary_name}"}
-              success_runs = [run_version(binary, root, success_env) for _ in range(2)]
-
-          server.shutdown()
-          thread.join(timeout=5)
+              install_platform_package(root, repo)
+              ignored_url_env = {**env, "OPENSWARM_TUI_URL": "https://127.0.0.1:9/should-not-be-read"}
+              version_runs = [run_version(binary, root, ignored_url_env) for _ in range(2)]
 
           output = "\n".join(
               [
@@ -181,16 +156,8 @@ jobs:
                   "" if listing is None else listing.stderr,
               ]
               + [
-                  f"=== missing custom TUI run {idx} stdout ===\n{run.stdout}\n=== missing custom TUI run {idx} stderr ===\n{run.stderr}"
-                  for idx, run in enumerate(missing_runs, start=1)
-              ]
-              + [
-                  f"=== invalid run {idx} stdout ===\n{run.stdout}\n=== invalid run {idx} stderr ===\n{run.stderr}"
-                  for idx, run in enumerate(invalid_runs, start=1)
-              ]
-              + [
-                  f"=== custom run {idx} stdout ===\n{run.stdout}\n=== custom run {idx} stderr ===\n{run.stderr}"
-                  for idx, run in enumerate(success_runs, start=1)
+                  f"=== dependency binary run {idx} stdout ===\n{run.stdout}\n=== dependency binary run {idx} stderr ===\n{run.stderr}"
+                  for idx, run in enumerate(version_runs, start=1)
               ]
           )
           print(output)
@@ -203,27 +170,21 @@ jobs:
               print("FAILED: expected launcher not found after npm install")
               sys.exit(1)
 
-          for idx, run in enumerate(missing_runs, start=1):
-              if run.returncode == 0:
-                  print(f"FAILED: missing custom TUI run {idx} unexpectedly succeeded")
-                  sys.exit(1)
-              stderr = run.stderr.lower()
-              if "custom openswarm tui unavailable" not in stderr or "openswarm_tui_url" not in stderr:
-                  print(f"FAILED: missing custom TUI run {idx} did not print actionable custom TUI unavailable message")
-                  sys.exit(1)
+          config = root / "node_modules" / "@vrsen" / "openswarm" / "openswarm.config.mjs"
+          if not config.exists():
+              print("FAILED: openswarm.config.mjs was not included in the npm package")
+              sys.exit(1)
 
-          for idx, run in enumerate(success_runs, start=1):
+          for idx, run in enumerate(version_runs, start=1):
               if run.returncode != 0:
-                  print(f"FAILED: custom run {idx} exited with {run.returncode}")
+                  print(f"FAILED: dependency binary run {idx} exited with {run.returncode}")
                   sys.exit(1)
-
-          for idx, run in enumerate(invalid_runs, start=1):
-              if run.returncode == 0:
-                  print(f"FAILED: invalid run {idx} unexpectedly succeeded")
+              version = next((line.strip() for line in reversed(run.stdout.splitlines()) if line.strip()), "")
+              if version != package_version:
+                  print(f"FAILED: dependency binary run {idx} returned {version!r}, expected {package_version!r}")
                   sys.exit(1)
-              stderr = run.stderr.lower()
-              if "custom openswarm tui unavailable" not in stderr or "openswarm_tui_url" not in stderr:
-                  print(f"FAILED: invalid run {idx} did not print actionable custom TUI unavailable message")
+              if "Downloading OpenSwarm TUI" in run.stdout or "Downloading OpenSwarm TUI" in run.stderr:
+                  print(f"FAILED: dependency binary run {idx} attempted a runtime TUI download")
                   sys.exit(1)
 
           banned = [
@@ -237,16 +198,4 @@ jobs:
               if needle.lower() in lower_output:
                   print(f"FAILED: found unexpected output: {needle}")
                   sys.exit(1)
-
-          custom_version = next(
-              (
-                  line.strip()
-                  for line in reversed(success_runs[-1].stdout.splitlines())
-                  if line.strip()
-              ),
-              "",
-          )
-          if custom_version != "9.9.9-custom":
-              print(f"FAILED: unexpected custom version output: {custom_version!r}")
-              sys.exit(1)
           EOF

--- a/bin/openswarm
+++ b/bin/openswarm
@@ -1,74 +1,128 @@
 #!/usr/bin/env node
 'use strict'
 
-const { spawnSync } = require('child_process')
+const childProcess = require('child_process')
 const fs = require('fs')
-const http = require('http')
-const https = require('https')
-const os = require('os')
 const path = require('path')
+const { pathToFileURL } = require('url')
 
 const scriptPath = fs.realpathSync(__filename)
 const packageDir = path.dirname(path.dirname(scriptPath))
 const packageJson = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'))
-const productTuiLogoLeft = [
-  '                                    ',
-  ' ██████╗ ██████╗ ███████╗███╗   ██╗',
-  '██╔═══██╗██╔══██╗██╔════╝████╗  ██║',
-  '██║   ██║██████╔╝█████╗  ██╔██╗ ██║',
-  '██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║',
-  '╚██████╔╝██║     ███████╗██║ ╚████║',
-  ' ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝',
-]
-const productTuiLogoRight = [
-  '',
-  '███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗',
-  '██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║',
-  '███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║',
-  '╚════██║██║███╗██║██╔══██║██╔══██╗██║╚██╔╝██║',
-  '███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║',
-  '╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝',
-]
-const productWordmarkLines = productTuiLogoLeft.map((line, index) => `${line} ${productTuiLogoRight[index] ?? ''}`.trimEnd())
-const productAddons = [
-  { id: 'search', title: 'Web Search', keys: ['SEARCH_API_KEY'] },
-  { id: 'anthropic', title: 'Anthropic Claude', keys: ['ANTHROPIC_API_KEY'], excludeProviders: ['anthropic'] },
-  { id: 'composio', title: 'Composio', keys: ['COMPOSIO_API_KEY', 'COMPOSIO_USER_ID'] },
-  { id: 'google', title: 'Google Gemini', keys: ['GOOGLE_API_KEY'], excludeProviders: ['google'] },
-  { id: 'fal', title: 'Fal.ai', keys: ['FAL_KEY'] },
-  { id: 'pexels', title: 'Pexels', keys: ['PEXELS_API_KEY'] },
-  { id: 'pixabay', title: 'Pixabay', keys: ['PIXABAY_API_KEY'] },
-  { id: 'unsplash', title: 'Unsplash', keys: ['UNSPLASH_ACCESS_KEY'] },
-]
-function resolveStateRoot() {
-  const explicit = process.env.OPENSWARM_STATE_ROOT && process.env.OPENSWARM_STATE_ROOT.trim()
-  if (explicit) return path.resolve(explicit)
-  if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'OpenSwarm')
-  }
-  return path.join(os.homedir(), '.openswarm')
+
+function platformPackages() {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
+  const platform = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux'
+  const extension = process.platform === 'win32' ? '.exe' : ''
+  const base = `@vrsen/openswarm-cli-${platform}-${arch}`
+  const binary = `agentswarm${extension}`
+  const baseline = arch === 'x64' && !supportsAvx2(platform, arch)
+  return packageSpecs(packageNames(platform, arch, base, baseline), binary)
 }
 
-const downstreamEnv = {
-  AGENTSWARM_PRODUCT_DISPLAY_NAME: 'OpenSwarm',
-  AGENTSWARM_PRODUCT_COMMAND: 'openswarm',
-  AGENTSWARM_PRODUCT_PACKAGE_NAME: '@vrsen/openswarm',
-  AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: '@vrsen/openswarm',
-  AGENTSWARM_PRODUCT_RELEASE_REPO: 'VRSEN/OpenSwarm',
-  AGENTSWARM_PRODUCT_DOCS_URL: 'https://github.com/VRSEN/OpenSwarm',
-  AGENTSWARM_PRODUCT_ISSUE_URL: 'https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml',
-  AGENTSWARM_PRODUCT_MDNS_DOMAIN: 'openswarm.local',
-  AGENTSWARM_PRODUCT_STARTER_REPO: 'VRSEN/OpenSwarm',
-  AGENTSWARM_PRODUCT_STARTER_FOLDER: 'openswarm',
-  AGENTSWARM_PRODUCT_ENTRY_FILES: 'swarm.py',
-  AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION: 'true',
-  AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: JSON.stringify(productTuiLogoLeft),
-  AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: JSON.stringify(productTuiLogoRight),
-  AGENTSWARM_PRODUCT_WORDMARK_LINES: JSON.stringify(productWordmarkLines),
-  AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: 'standalone',
-  AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(productAddons),
-  AGENTSWARM_PRODUCT_STATE_ROOT: resolveStateRoot(),
-  AGENTSWARM_PRODUCT_VERSION: packageJson.version,
+function packageSpecs(names, binary) {
+  return names.map((name) => ({ name, binary }))
+}
+
+function packageNames(platform, arch, base, baseline) {
+  if (platform === 'linux') {
+    const musl = isMusl()
+    if (arch === 'x64') {
+      if (musl) {
+        if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+        return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+      }
+      if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+      return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+    }
+    if (musl) return [`${base}-musl`, base]
+    return [base, `${base}-musl`]
+  }
+
+  if (arch === 'x64') {
+    if (baseline) return [`${base}-baseline`, base]
+    return [base, `${base}-baseline`]
+  }
+
+  return [base]
+}
+
+function supportsAvx2(platform, arch) {
+  if (arch !== 'x64') return false
+
+  if (platform === 'linux') {
+    try {
+      return /(^|\s)avx2(\s|$)/i.test(fs.readFileSync('/proc/cpuinfo', 'utf8'))
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === 'darwin') {
+    try {
+      const result = childProcess.spawnSync('sysctl', ['-n', 'hw.optional.avx2_0'], {
+        encoding: 'utf8',
+        timeout: 1500,
+      })
+      if (result.status !== 0) return false
+      return (result.stdout || '').trim() === '1'
+    } catch {
+      return false
+    }
+  }
+
+  if (platform === 'windows') {
+    const cmd =
+      '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)'
+    for (const exe of ['powershell.exe', 'pwsh.exe', 'pwsh', 'powershell']) {
+      try {
+        const result = childProcess.spawnSync(exe, ['-NoProfile', '-NonInteractive', '-Command', cmd], {
+          encoding: 'utf8',
+          timeout: 3000,
+          windowsHide: true,
+        })
+        if (result.status !== 0) continue
+        const out = (result.stdout || '').trim().toLowerCase()
+        if (out === 'true' || out === '1') return true
+        if (out === 'false' || out === '0') return false
+      } catch {
+        continue
+      }
+    }
+  }
+
+  return false
+}
+
+function isMusl() {
+  try {
+    if (fs.existsSync('/etc/alpine-release')) return true
+  } catch {}
+
+  try {
+    const result = childProcess.spawnSync('ldd', ['--version'], { encoding: 'utf8' })
+    const text = `${result.stdout || ''}${result.stderr || ''}`.toLowerCase()
+    return text.includes('musl')
+  } catch {
+    return false
+  }
+}
+
+function resolveOpenSwarmBinary(startDir) {
+  const tried = []
+  for (const spec of platformPackages()) {
+    let current = startDir
+    const parts = spec.name.split('/')
+    for (;;) {
+      const candidate = path.join(current, 'node_modules', ...parts, 'bin', spec.binary)
+      tried.push(candidate)
+      if (fs.existsSync(candidate)) return candidate
+      const parent = path.dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+  }
+  return { tried }
 }
 
 function resolveAgentswarm(startDir) {
@@ -88,176 +142,13 @@ function resolveAgentswarm(startDir) {
   }
 }
 
-function getBinaryNames() {
-  const arch = os.arch() === 'arm64' ? 'arm64' : 'x64'
-  const platform = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'darwin' : 'linux'
-  const extension = process.platform === 'win32' ? '.exe' : ''
-  const names = [`agentswarm-${platform}-${arch}${extension}`]
-  if (arch === 'x64') {
-    names.push(`agentswarm-${platform}-${arch}-baseline${extension}`)
-  }
-  return names
-}
-
-function hasExplicitTuiUrl() {
-  return Boolean(process.env.OPENSWARM_TUI_URL && process.env.OPENSWARM_TUI_URL.trim())
-}
-
-function isMuslLinux() {
-  if (process.platform !== 'linux') return false
-
-  try {
-    if (fs.existsSync('/etc/alpine-release')) return true
-  } catch {}
-
-  try {
-    const result = spawnSync('ldd', ['--version'], {
-      encoding: 'utf8',
-      timeout: 1500,
-    })
-    const output = `${result.stdout || ''}\n${result.stderr || ''}`.toLowerCase()
-    return output.includes('musl')
-  } catch {
-    return false
-  }
-}
-
-function shouldUseDependencyBinary() {
-  return isMuslLinux() && !hasExplicitTuiUrl()
-}
-
-function getDownloadUrl(binaryName) {
-  const explicit = hasExplicitTuiUrl() ? process.env.OPENSWARM_TUI_URL.trim() : ''
-  if (explicit) return explicit
-  return `https://github.com/VRSEN/OpenSwarm/releases/download/v${packageJson.version}/${binaryName}`
-}
-
-function resolveCustomBinary(binaryPath) {
-  try {
-    const stat = fs.statSync(binaryPath)
-    if (!stat.isFile() || stat.size <= 0) return null
-    if (process.platform !== 'win32' && (stat.mode & 0o111) === 0) {
-      fs.chmodSync(binaryPath, 0o755)
-    }
-    if (!validateBinary(binaryPath)) return null
-    return binaryPath
-  } catch {
-    return null
-  }
-}
-
-function validateBinary(binaryPath) {
-  const result = spawnSync(binaryPath, ['--version'], {
-    env: {
-      ...process.env,
-      AGENTSWARM_LAUNCHER: '0',
-      ...downstreamEnv,
-    },
-    encoding: 'utf8',
-    timeout: 15000,
-  })
-  if (result.error) return false
-  if (typeof result.status !== 'number' || result.status !== 0) return false
-  const output = `${result.stdout || ''}\n${result.stderr || ''}`
-  return /\d+\.\d+\.\d+/.test(output)
-}
-
-function request(url, redirects = 0) {
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https:') ? https : url.startsWith('http:') ? http : null
-    if (!client) {
-      reject(new Error(`Unsupported protocol for ${url}`))
-      return
-    }
-
-    const req = client.get(
-      url,
-      {
-        headers: {
-          'User-Agent': '@vrsen/openswarm',
-        },
-      },
-      (res) => {
-        if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
-          res.resume()
-          if (redirects >= 5) {
-            reject(new Error('Too many redirects'))
-            return
-          }
-          resolve(request(new URL(res.headers.location, url).toString(), redirects + 1))
-          return
-        }
-        if (res.statusCode !== 200) {
-          res.resume()
-          reject(new Error(`HTTP ${res.statusCode}`))
-          return
-        }
-        resolve(res)
-      },
-    )
-
-    req.setTimeout(30000, () => req.destroy(new Error('Request timed out')))
-    req.on('error', reject)
-  })
-}
-
-async function download(url, destination) {
-  const tempPath = `${destination}.part-${process.pid}-${Date.now()}`
-  let finished = false
-  try {
-    const response = await request(url)
-    await new Promise((resolve, reject) => {
-      const file = fs.createWriteStream(tempPath)
-      response.on('error', reject)
-      file.on('error', reject)
-      file.on('close', resolve)
-      response.pipe(file)
-    })
-    const stat = fs.statSync(tempPath)
-    if (!stat.isFile() || stat.size <= 0) {
-      throw new Error('Empty download')
-    }
-    if (process.platform !== 'win32') {
-      fs.chmodSync(tempPath, 0o755)
-    }
-    fs.rmSync(destination, { force: true })
-    fs.renameSync(tempPath, destination)
-    finished = true
-  } finally {
-    if (!finished) {
-      fs.rmSync(tempPath, { force: true })
-    }
-  }
-}
-
-async function ensureCustomBinary() {
-  if (shouldUseDependencyBinary()) return null
-
-  const binaryNames = getBinaryNames()
-  for (const binaryName of binaryNames) {
-    const existing = resolveCustomBinary(path.join(packageDir, binaryName))
-    if (existing) return existing
-  }
-
-  process.stdout.write('Downloading OpenSwarm TUI...\n')
-  const errors = []
-  for (const binaryName of binaryNames) {
-    const binaryPath = path.join(packageDir, binaryName)
-    fs.rmSync(binaryPath, { force: true })
-    try {
-      await download(getDownloadUrl(binaryName), binaryPath)
-      const resolved = resolveCustomBinary(binaryPath)
-      if (resolved) return resolved
-      fs.rmSync(binaryPath, { force: true })
-      throw new Error('Downloaded custom TUI binary failed validation')
-    } catch (error) {
-      fs.rmSync(binaryPath, { force: true })
-      errors.push(`${binaryName}: ${error instanceof Error ? error.message : String(error)}`)
-    }
-  }
-  throw new Error(
-    `custom OpenSwarm TUI unavailable (${errors.join('; ')}). Reinstall @vrsen/openswarm or set OPENSWARM_TUI_URL to a valid binary.`,
+const openswarmBinary = resolveOpenSwarmBinary(packageDir)
+if (!openswarmBinary || typeof openswarmBinary !== 'string') {
+  const packages = platformPackages().map((item) => item.name).join(', ')
+  process.stderr.write(
+    `openswarm: could not resolve an OpenSwarm TUI binary package for this platform. Reinstall @vrsen/openswarm with optional dependencies enabled. Expected one of: ${packages}.\n`,
   )
+  process.exit(1)
 }
 
 const agentswarmBin = resolveAgentswarm(packageDir)
@@ -267,17 +158,17 @@ if (!agentswarmBin) {
 }
 
 async function main() {
-  const customBinary = await ensureCustomBinary()
+  const config = await import(pathToFileURL(path.join(packageDir, 'openswarm.config.mjs')).href)
   const env = {
     ...process.env,
-    ...downstreamEnv,
+    ...config.getProductEnv({ version: packageJson.version }),
     AGENTSWARM_LAUNCHER: process.env.AGENTSWARM_LAUNCHER || '1',
+    AGENTSWARM_BIN_PATH: openswarmBinary,
     PYTHONUTF8: process.env.PYTHONUTF8 || '1',
     PYTHONIOENCODING: process.env.PYTHONIOENCODING || 'utf-8',
   }
-  if (customBinary) env.AGENTSWARM_BIN_PATH = customBinary
 
-  const result = spawnSync(process.execPath, [agentswarmBin, ...process.argv.slice(2)], {
+  const result = childProcess.spawnSync(process.execPath, [agentswarmBin, ...process.argv.slice(2)], {
     stdio: 'inherit',
     env,
   })

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -1,0 +1,96 @@
+import os from "node:os"
+import path from "node:path"
+
+// Downstream projects can edit this file to rebrand the launcher and TUI build.
+export const product = {
+  displayName: "OpenSwarm",
+  command: "openswarm",
+  packageName: "@vrsen/openswarm",
+  launcherPackageName: "@vrsen/openswarm",
+  releaseRepo: "VRSEN/OpenSwarm",
+  docsUrl: "https://github.com/VRSEN/OpenSwarm",
+  issueUrl: "https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml",
+  mdnsDomain: "openswarm.local",
+  starterRepo: "VRSEN/OpenSwarm",
+  starterFolder: "openswarm",
+  entryFiles: "swarm.py",
+}
+
+export const productTuiLogoLeft = [
+  "                                    ",
+  " ██████╗ ██████╗ ███████╗███╗   ██╗",
+  "██╔═══██╗██╔══██╗██╔════╝████╗  ██║",
+  "██║   ██║██████╔╝█████╗  ██╔██╗ ██║",
+  "██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║",
+  "╚██████╔╝██║     ███████╗██║ ╚████║",
+  " ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝",
+]
+
+export const productTuiLogoRight = [
+  "",
+  "███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗",
+  "██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║",
+  "███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║",
+  "╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║",
+  "███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║",
+  "╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝",
+]
+
+export const productWordmarkLines = productTuiLogoLeft.map((line, index) =>
+  `${line} ${productTuiLogoRight[index] ?? ""}`.trimEnd(),
+)
+
+export const productAddons = [
+  { id: "search", title: "Web Search", keys: ["SEARCH_API_KEY"] },
+  { id: "anthropic", title: "Anthropic Claude", keys: ["ANTHROPIC_API_KEY"], excludeProviders: ["anthropic"] },
+  { id: "composio", title: "Composio", keys: ["COMPOSIO_API_KEY", "COMPOSIO_USER_ID"] },
+  { id: "google", title: "Google Gemini", keys: ["GOOGLE_API_KEY"], excludeProviders: ["google"] },
+  { id: "fal", title: "Fal.ai", keys: ["FAL_KEY"] },
+  { id: "pexels", title: "Pexels", keys: ["PEXELS_API_KEY"] },
+  { id: "pixabay", title: "Pixabay", keys: ["PIXABAY_API_KEY"] },
+  { id: "unsplash", title: "Unsplash", keys: ["UNSPLASH_ACCESS_KEY"] },
+]
+
+export function resolveStateRoot(env = process.env, platform = process.platform, home = os.homedir()) {
+  const explicit = env.OPENSWARM_STATE_ROOT && env.OPENSWARM_STATE_ROOT.trim()
+  if (explicit) return path.resolve(explicit)
+  if (platform === "win32") {
+    return path.join(env.APPDATA || path.join(home, "AppData", "Roaming"), "OpenSwarm")
+  }
+  return path.join(home, ".openswarm")
+}
+
+export function getProductEnv(opts = {}) {
+  return {
+    AGENTSWARM_PRODUCT_DISPLAY_NAME: product.displayName,
+    AGENTSWARM_PRODUCT_COMMAND: product.command,
+    AGENTSWARM_PRODUCT_PACKAGE_NAME: product.packageName,
+    AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME: product.launcherPackageName,
+    AGENTSWARM_PRODUCT_RELEASE_REPO: product.releaseRepo,
+    AGENTSWARM_PRODUCT_DOCS_URL: product.docsUrl,
+    AGENTSWARM_PRODUCT_ISSUE_URL: product.issueUrl,
+    AGENTSWARM_PRODUCT_MDNS_DOMAIN: product.mdnsDomain,
+    AGENTSWARM_PRODUCT_STARTER_REPO: product.starterRepo,
+    AGENTSWARM_PRODUCT_STARTER_FOLDER: product.starterFolder,
+    AGENTSWARM_PRODUCT_ENTRY_FILES: product.entryFiles,
+    AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION: "true",
+    AGENTSWARM_PRODUCT_TUI_LOGO_LEFT: JSON.stringify(productTuiLogoLeft),
+    AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT: JSON.stringify(productTuiLogoRight),
+    AGENTSWARM_PRODUCT_WORDMARK_LINES: JSON.stringify(productWordmarkLines),
+    AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT: "standalone",
+    AGENTSWARM_PRODUCT_ENABLE_ADDONS: "true",
+    AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(productAddons),
+    AGENTSWARM_PRODUCT_STATE_ROOT: opts.stateRoot ?? resolveStateRoot(opts.env),
+    AGENTSWARM_PRODUCT_VERSION: opts.version,
+  }
+}
+
+export default {
+  product,
+  productTuiLogoLeft,
+  productTuiLogoRight,
+  productWordmarkLines,
+  productAddons,
+  resolveStateRoot,
+  getProductEnv,
+}

--- a/openswarm.product-env.json
+++ b/openswarm.product-env.json
@@ -1,0 +1,20 @@
+{
+  "AGENTSWARM_PRODUCT_DISPLAY_NAME": "OpenSwarm",
+  "AGENTSWARM_PRODUCT_COMMAND": "openswarm",
+  "AGENTSWARM_PRODUCT_PACKAGE_NAME": "@vrsen/openswarm",
+  "AGENTSWARM_PRODUCT_LAUNCHER_PACKAGE_NAME": "@vrsen/openswarm",
+  "AGENTSWARM_PRODUCT_RELEASE_REPO": "VRSEN/OpenSwarm",
+  "AGENTSWARM_PRODUCT_DOCS_URL": "https://github.com/VRSEN/OpenSwarm",
+  "AGENTSWARM_PRODUCT_ISSUE_URL": "https://github.com/VRSEN/OpenSwarm/issues/new?template=bug-report.yml",
+  "AGENTSWARM_PRODUCT_MDNS_DOMAIN": "openswarm.local",
+  "AGENTSWARM_PRODUCT_STARTER_REPO": "VRSEN/OpenSwarm",
+  "AGENTSWARM_PRODUCT_STARTER_FOLDER": "openswarm",
+  "AGENTSWARM_PRODUCT_ENTRY_FILES": "swarm.py",
+  "AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION": "true",
+  "AGENTSWARM_PRODUCT_TUI_LOGO_LEFT": "[\"                                    \",\" ██████╗ ██████╗ ███████╗███╗   ██╗\",\"██╔═══██╗██╔══██╗██╔════╝████╗  ██║\",\"██║   ██║██████╔╝█████╗  ██╔██╗ ██║\",\"██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║\",\"╚██████╔╝██║     ███████╗██║ ╚████║\",\" ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝\"]",
+  "AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT": "[\"\",\"███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗\",\"██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║\",\"███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║\",\"╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║\",\"███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║\",\"╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝\"]",
+  "AGENTSWARM_PRODUCT_WORDMARK_LINES": "[\"\",\" ██████╗ ██████╗ ███████╗███╗   ██╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗\",\"██╔═══██╗██╔══██╗██╔════╝████╗  ██║ ██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║\",\"██║   ██║██████╔╝█████╗  ██╔██╗ ██║ ███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║\",\"██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║ ╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║\",\"╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║\",\" ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝\"]",
+  "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT": "standalone",
+  "AGENTSWARM_PRODUCT_ENABLE_ADDONS": "true",
+  "AGENTSWARM_PRODUCT_ADDONS": "[{\"id\":\"search\",\"title\":\"Web Search\",\"keys\":[\"SEARCH_API_KEY\"]},{\"id\":\"anthropic\",\"title\":\"Anthropic Claude\",\"keys\":[\"ANTHROPIC_API_KEY\"],\"excludeProviders\":[\"anthropic\"]},{\"id\":\"composio\",\"title\":\"Composio\",\"keys\":[\"COMPOSIO_API_KEY\",\"COMPOSIO_USER_ID\"]},{\"id\":\"google\",\"title\":\"Google Gemini\",\"keys\":[\"GOOGLE_API_KEY\"],\"excludeProviders\":[\"google\"]},{\"id\":\"fal\",\"title\":\"Fal.ai\",\"keys\":[\"FAL_KEY\"]},{\"id\":\"pexels\",\"title\":\"Pexels\",\"keys\":[\"PEXELS_API_KEY\"]},{\"id\":\"pixabay\",\"title\":\"Pixabay\",\"keys\":[\"PIXABAY_API_KEY\"]},{\"id\":\"unsplash\",\"title\":\"Unsplash\",\"keys\":[\"UNSPLASH_ACCESS_KEY\"]}]"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,20 @@
             "engines": {
                 "node": ">=18.0.0",
                 "python": ">=3.10"
+            },
+            "optionalDependencies": {
+                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.7",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.7"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -643,6 +657,150 @@
             "version": "1.4.37-rc.1",
             "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.37-rc.1.tgz",
             "integrity": "sha512-UphkBJ+d28WN/tzA+d4b0K6KDNhNY5pqFMaYDiAoETUUFaltzG3pXEudqH+dmdpjHgDkkGhQV6srAoQ6bA8ntg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-darwin-x64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-arm64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-x64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-windows-arm64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-windows-x64": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.7.tgz",
+            "license": "MIT",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
+            "version": "1.0.1-rc.7",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.7.tgz",
+            "license": "MIT",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     },
     "files": [
         "bin/",
+        "openswarm.config.mjs",
+        "openswarm.product-env.json",
         "run_utils.py",
         "onboard.py",
         "swarm.py",
@@ -45,6 +47,20 @@
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.0",
         "sharp": "^0.33.0"
+    },
+    "optionalDependencies": {
+        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.7",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.7"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,7 @@ where = ["."]
 exclude = ["agentswarm-cli*", "venv*", ".venv*", ".agency_swarm*", "node_modules*", "*.node_modules*", "activity*", "mnt*", "pptx*", "slides"]
 
 [tool.setuptools.package-data]
-"*" = ["*.md", "*.json", "agency-*"]
+"*" = ["*.md", "*.json", "*.mjs", "agency-*"]
+
+[tool.setuptools.data-files]
+"." = ["openswarm.config.mjs", "openswarm.product-env.json", "package.json"]

--- a/run_utils.py
+++ b/run_utils.py
@@ -1,47 +1,12 @@
+import json
 import os
 import sys
+import site
 import subprocess
 import shutil
 import tempfile
+import platform as platform_module
 from pathlib import Path
-
-_PRODUCT_TUI_LOGO_LEFT = (
-    '["                                    ",'
-    '" ██████╗ ██████╗ ███████╗███╗   ██╗",'
-    '"██╔═══██╗██╔══██╗██╔════╝████╗  ██║",'
-    '"██║   ██║██████╔╝█████╗  ██╔██╗ ██║",'
-    '"██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║",'
-    '"╚██████╔╝██║     ███████╗██║ ╚████║",'
-    '" ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝"]'
-)
-_PRODUCT_TUI_LOGO_RIGHT = (
-    '["",'
-    '"███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗",'
-    '"██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║",'
-    '"███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║",'
-    '"╚════██║██║███╗██║██╔══██║██╔══██╗██║╚██╔╝██║",'
-    '"███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║",'
-    '"╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-)
-_PRODUCT_WORDMARK_LINES = (
-    '["",'
-    '" ██████╗ ██████╗ ███████╗███╗   ██╗ ███████╗██╗    ██╗ █████╗ ██████╗ ███╗   ███╗",'
-    '"██╔═══██╗██╔══██╗██╔════╝████╗  ██║ ██╔════╝██║    ██║██╔══██╗██╔══██╗████╗ ████║",'
-    '"██║   ██║██████╔╝█████╗  ██╔██╗ ██║ ███████╗██║ █╗ ██║███████║██████╔╝██╔████╔██║",'
-    '"██║   ██║██╔═══╝ ██╔══╝  ██║╚██╗██║ ╚════██║██║███╗██║██╔══██╗██╔══██╗██║╚██╔╝██║",'
-    '"╚██████╔╝██║     ███████╗██║ ╚████║ ███████║╚███╔███╔╝██║  ██║██║  ██║██║ ╚═╝ ██║",'
-    '" ╚═════╝ ╚═╝     ╚══════╝╚═╝  ╚═══╝ ╚══════╝ ╚══╝╚══╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝"]'
-)
-_PRODUCT_ADDONS = (
-    '[{"id":"search","title":"Web Search","keys":["SEARCH_API_KEY"]},'
-    '{"id":"anthropic","title":"Anthropic Claude","keys":["ANTHROPIC_API_KEY"],"excludeProviders":["anthropic"]},'
-    '{"id":"composio","title":"Composio","keys":["COMPOSIO_API_KEY","COMPOSIO_USER_ID"]},'
-    '{"id":"google","title":"Google Gemini","keys":["GOOGLE_API_KEY"],"excludeProviders":["google"]},'
-    '{"id":"fal","title":"Fal.ai","keys":["FAL_KEY"]},'
-    '{"id":"pexels","title":"Pexels","keys":["PEXELS_API_KEY"]},'
-    '{"id":"pixabay","title":"Pixabay","keys":["PIXABAY_API_KEY"]},'
-    '{"id":"unsplash","title":"Unsplash","keys":["UNSPLASH_ACCESS_KEY"]}]'
-)
 
 
 def _openswarm_state_root() -> Path:
@@ -58,13 +23,224 @@ def _load_openswarm_dotenv(*, override: bool = False) -> bool:
     return bool(load_dotenv(dotenv_path=_openswarm_state_root() / ".env", override=override))
 
 
+def _product_env_from_config() -> dict[str, str]:
+    config = package = fallback = None
+    for root in (Path(__file__).resolve().parent, Path(sys.prefix), Path(site.USER_BASE)):
+        candidate_config = root / "openswarm.config.mjs"
+        candidate_fallback = root / "openswarm.product-env.json"
+        candidate_package = root / "package.json"
+        if not fallback and candidate_fallback.exists() and candidate_package.exists():
+            fallback = candidate_fallback
+            package = candidate_package
+        if candidate_config.exists() and candidate_package.exists():
+            config = candidate_config
+            package = candidate_package
+            break
+    node = shutil.which("node")
+    if node and config and package:
+        return _product_env_from_mjs(node, config, package)
+    if fallback and package:
+        return _product_env_from_json(fallback, package)
+    if not node and config and package:
+        raise RuntimeError("OpenSwarm product config requires Node.js or openswarm.product-env.json. Reinstall OpenSwarm through npm or npx.")
+    if not config and not fallback:
+        raise RuntimeError("OpenSwarm product config files are missing. Reinstall OpenSwarm through npm or npx.")
+    raise RuntimeError("OpenSwarm package metadata is missing. Reinstall OpenSwarm through npm or npx.")
+
+
+def _product_env_from_mjs(node: str, config: Path, package: Path) -> dict[str, str]:
+    script = (
+        "const fs=require('fs');"
+        "const {pathToFileURL}=require('url');"
+        "import(pathToFileURL(process.argv[1]).href).then((cfg)=>{"
+        "const pkg=JSON.parse(fs.readFileSync(process.argv[3],'utf8'));"
+        "process.stdout.write(JSON.stringify(cfg.getProductEnv({stateRoot:process.argv[2],version:pkg.version})));"
+        "}).catch((err)=>{console.error(err&&err.stack||err);process.exit(1);});"
+    )
+    result = subprocess.run(
+        [node, "-e", script, str(config), str(_openswarm_state_root()), str(package)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        timeout=15,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"OpenSwarm product config failed to load: {result.stderr.strip()}")
+    return {key: str(value) for key, value in json.loads(result.stdout).items()}
+
+
+def _product_env_from_json(fallback: Path, package: Path) -> dict[str, str]:
+    try:
+        values = json.loads(fallback.read_text(encoding="utf-8"))
+        pkg = json.loads(package.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"OpenSwarm product config fallback failed to load: {exc}") from exc
+    if not isinstance(values, dict) or not isinstance(pkg, dict) or not pkg.get("version"):
+        raise RuntimeError("OpenSwarm product config fallback is invalid. Reinstall OpenSwarm through npm or npx.")
+    env = {key: str(value) for key, value in values.items()}
+    env["AGENTSWARM_PRODUCT_STATE_ROOT"] = str(_openswarm_state_root())
+    env["AGENTSWARM_PRODUCT_VERSION"] = str(pkg["version"])
+    return env
+
+
 def _configure_product_env() -> None:
-    os.environ.setdefault("AGENTSWARM_PRODUCT_SKIP_POST_AUTH_MODEL_SELECTION", "true")
-    os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_LEFT", _PRODUCT_TUI_LOGO_LEFT)
-    os.environ.setdefault("AGENTSWARM_PRODUCT_TUI_LOGO_RIGHT", _PRODUCT_TUI_LOGO_RIGHT)
-    os.environ.setdefault("AGENTSWARM_PRODUCT_WORDMARK_LINES", _PRODUCT_WORDMARK_LINES)
-    os.environ.setdefault("AGENTSWARM_PRODUCT_ADDONS", _PRODUCT_ADDONS)
-    os.environ["AGENTSWARM_PRODUCT_STATE_ROOT"] = str(_openswarm_state_root())
+    for key, value in _product_env_from_config().items():
+        if key == "AGENTSWARM_PRODUCT_STATE_ROOT":
+            os.environ[key] = value
+        else:
+            os.environ.setdefault(key, value)
+
+
+def _openswarm_package_names(platform: str, arch: str, *, musl: bool, baseline: bool) -> list[str]:
+    base = f"@vrsen/openswarm-cli-{platform}-{arch}"
+    if platform == "linux":
+        if arch == "x64":
+            if musl:
+                if baseline:
+                    return [f"{base}-baseline-musl", f"{base}-musl", f"{base}-baseline", base]
+                return [f"{base}-musl", f"{base}-baseline-musl", base, f"{base}-baseline"]
+            if baseline:
+                return [f"{base}-baseline", base, f"{base}-baseline-musl", f"{base}-musl"]
+            return [base, f"{base}-baseline", f"{base}-musl", f"{base}-baseline-musl"]
+        if musl:
+            return [f"{base}-musl", base]
+        return [base, f"{base}-musl"]
+
+    if arch == "x64":
+        if baseline:
+            return [f"{base}-baseline", base]
+        return [base, f"{base}-baseline"]
+
+    return [base]
+
+
+def _openswarm_platform() -> str:
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "darwin"
+    return "linux"
+
+
+def _openswarm_arch() -> str:
+    machine = platform_module.machine().lower()
+    if machine in {"arm64", "aarch64"}:
+        return "arm64"
+    return "x64"
+
+
+def _supports_avx2(platform: str, arch: str) -> bool:
+    if arch != "x64":
+        return False
+
+    if platform == "linux":
+        try:
+            return " avx2 " in f" {Path('/proc/cpuinfo').read_text(encoding='utf-8').lower()} "
+        except OSError:
+            return False
+
+    if platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", "hw.optional.avx2_0"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+                timeout=1.5,
+                check=False,
+            )
+        except OSError:
+            return False
+        return result.returncode == 0 and result.stdout.strip() == "1"
+
+    if platform == "windows":
+        cmd = (
+            '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool '
+            'IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 '
+            "-PassThru)::IsProcessorFeaturePresent(40)"
+        )
+        for exe in ("powershell.exe", "pwsh.exe", "pwsh", "powershell"):
+            try:
+                result = subprocess.run(
+                    [exe, "-NoProfile", "-NonInteractive", "-Command", cmd],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    encoding="utf-8",
+                    timeout=3,
+                    check=False,
+                )
+            except OSError:
+                continue
+            if result.returncode != 0:
+                continue
+            value = result.stdout.strip().lower()
+            if value in {"true", "1"}:
+                return True
+            if value in {"false", "0"}:
+                return False
+
+    return False
+
+
+def _is_musl() -> bool:
+    if sys.platform != "linux":
+        return False
+    if Path("/etc/alpine-release").exists():
+        return True
+    try:
+        result = subprocess.run(
+            ["ldd", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            timeout=1.5,
+            check=False,
+        )
+    except OSError:
+        return False
+    return "musl" in f"{result.stdout}{result.stderr}".lower()
+
+
+def _openswarm_platform_packages() -> list[tuple[str, str]]:
+    platform = _openswarm_platform()
+    arch = _openswarm_arch()
+    baseline = arch == "x64" and not _supports_avx2(platform, arch)
+    binary = "agentswarm.exe" if platform == "windows" else "agentswarm"
+    names = _openswarm_package_names(platform, arch, musl=_is_musl(), baseline=baseline)
+    return [(name, binary) for name in names]
+
+
+def _node_module_starts(repo: Path | None) -> list[Path]:
+    roots = [Path(__file__).resolve().parent]
+    if repo is not None:
+        roots.insert(0, repo.resolve())
+
+    starts = []
+    seen: set[Path] = set()
+    for root in roots:
+        path = root.resolve()
+        if path in seen:
+            continue
+        seen.add(path)
+        starts.append(path)
+    return starts
+
+
+def _resolve_openswarm_tui_binary(repo: Path | None = None) -> Path | None:
+    for name, binary in _openswarm_platform_packages():
+        scope, package = name.split("/", 1)
+        for start in _node_module_starts(repo):
+            current = start
+            while True:
+                candidate = current / "node_modules" / scope / package / "bin" / binary
+                if candidate.is_file():
+                    return candidate
+                parent = current.parent
+                if parent == current:
+                    break
+                current = parent
+    return None
 
 
 def _preload_agentswarm_bin(repo: Path | None = None) -> None:
@@ -108,73 +284,9 @@ def _preload_agentswarm_bin(repo: Path | None = None) -> None:
             os.environ["AGENTSWARM_BIN"] = raw
             return
 
-
-def _resolve_bin_name() -> str:
-    """Return the platform+arch-specific TUI binary filename."""
-    import platform
-    machine = platform.machine().lower()
-    arch = "arm64" if machine in ("arm64", "aarch64") else "x64"
-    if sys.platform == "win32":
-        return f"agentswarm-windows-{arch}.exe"
-    if sys.platform == "darwin":
-        return f"agentswarm-darwin-{arch}"
-    return f"agentswarm-linux-{arch}"
-
-
-def _resolve_bin_names() -> list[str]:
-    name = _resolve_bin_name()
-    names = [name]
-    stem, suffix = (name[:-4], ".exe") if name.endswith(".exe") else (name, "")
-    if stem.endswith("-x64"):
-        names.append(f"{stem}-baseline{suffix}")
-    return names
-
-
-def _is_tui_binary_runnable(path: Path) -> bool:
-    try:
-        stat = path.stat()
-        if not stat.st_size:
-            return False
-        if sys.platform != "win32" and not os.access(path, os.X_OK):
-            path.chmod(0o755)
-        result = subprocess.run(
-            [str(path), "--version"],
-            env={**os.environ, "AGENTSWARM_LAUNCHER": "0"},
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=15,
-        )
-    except Exception:
-        return False
-    return result.returncode == 0
-
-
-def _download_tui_binary(repo: Path, name: str) -> Path | None:
-    import urllib.request
-
-    path = repo / name
-    url = f"https://github.com/VRSEN/OpenSwarm/releases/latest/download/{name}"
-    print("Downloading OpenSwarm TUI, please wait…\n")
-    try:
-        urllib.request.urlretrieve(url, str(path))
-        if sys.platform != "win32":
-            path.chmod(0o755)
-        print("\nDone.\n")
-    except Exception:
-        path.unlink(missing_ok=True)
-        return None
-    return path
-
-
-def _resolve_tui_binary(repo: Path, download: bool) -> Path | None:
-    for name in _resolve_bin_names():
-        path = repo / name
-        if not path.exists() and download:
-            path = _download_tui_binary(repo, name) or path
-        if path.exists() and _is_tui_binary_runnable(path):
-            return path
-    return None
+    binary = _resolve_openswarm_tui_binary(repo)
+    if binary:
+        os.environ["AGENTSWARM_BIN"] = str(binary)
 
 
 _REQUIRED_SLIDES_NODE_PACKAGES = (
@@ -350,13 +462,8 @@ def _bootstrap() -> None:
             "npm was not found; cannot install Slides Agent Node.js dependencies"
         )
 
-    # Download the OpenSwarm TUI binary from GitHub Releases if missing.
-    if not os.getenv("AGENTSWARM_BIN"):
-        _bin_path = _resolve_tui_binary(_repo, download=True)
-        if _bin_path:
-            os.environ["AGENTSWARM_BIN"] = str(_bin_path)
-        else:
-            print("Warning: Could not download a runnable OpenSwarm TUI. The terminal UI will use the default.\n")
+    _preload_agentswarm_bin(_repo)
+
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -443,12 +550,6 @@ def main() -> None:
     os.environ.setdefault("PYTHONUTF8", "1")
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
     _configure_product_env()
-
-    if not os.getenv("AGENTSWARM_BIN"):
-        _repo = Path(__file__).resolve().parent
-        local_exe = _resolve_tui_binary(_repo, download=True)
-        if local_exe:
-            os.environ["AGENTSWARM_BIN"] = str(local_exe)
 
     # Disable OpenAI Agents SDK tracing for terminal demo runs.
     try:

--- a/scripts/package-platform-binaries.mjs
+++ b/scripts/package-platform-binaries.mjs
@@ -1,0 +1,60 @@
+import fs from "node:fs"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+
+const root = process.cwd()
+const pkg = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"))
+const dist = path.resolve(process.argv[2] || "dist")
+const out = path.resolve(process.argv[3] || "platform-packages")
+
+const packages = [
+  ["agentswarm-darwin-arm64", "@vrsen/openswarm-cli-darwin-arm64", "darwin", "arm64", "agentswarm"],
+  ["agentswarm-darwin-x64", "@vrsen/openswarm-cli-darwin-x64", "darwin", "x64", "agentswarm"],
+  ["agentswarm-darwin-x64-baseline", "@vrsen/openswarm-cli-darwin-x64-baseline", "darwin", "x64", "agentswarm"],
+  ["agentswarm-linux-arm64", "@vrsen/openswarm-cli-linux-arm64", "linux", "arm64", "agentswarm"],
+  ["agentswarm-linux-arm64-musl", "@vrsen/openswarm-cli-linux-arm64-musl", "linux", "arm64", "agentswarm"],
+  ["agentswarm-linux-x64", "@vrsen/openswarm-cli-linux-x64", "linux", "x64", "agentswarm"],
+  ["agentswarm-linux-x64-baseline", "@vrsen/openswarm-cli-linux-x64-baseline", "linux", "x64", "agentswarm"],
+  ["agentswarm-linux-x64-baseline-musl", "@vrsen/openswarm-cli-linux-x64-baseline-musl", "linux", "x64", "agentswarm"],
+  ["agentswarm-linux-x64-musl", "@vrsen/openswarm-cli-linux-x64-musl", "linux", "x64", "agentswarm"],
+  ["agentswarm-windows-arm64.exe", "@vrsen/openswarm-cli-windows-arm64", "win32", "arm64", "agentswarm.exe"],
+  ["agentswarm-windows-x64.exe", "@vrsen/openswarm-cli-windows-x64", "win32", "x64", "agentswarm.exe"],
+  ["agentswarm-windows-x64-baseline.exe", "@vrsen/openswarm-cli-windows-x64-baseline", "win32", "x64", "agentswarm.exe"],
+]
+
+fs.rmSync(out, { recursive: true, force: true })
+fs.mkdirSync(out, { recursive: true })
+
+for (const [asset, name, os, cpu, binary] of packages) {
+  const src = path.join(dist, asset)
+  if (!fs.existsSync(src)) throw new Error(`missing platform asset: ${src}`)
+
+  const dir = path.join(out, name.replace("@vrsen/", "vrsen-"))
+  const bin = path.join(dir, "bin")
+  fs.mkdirSync(bin, { recursive: true })
+  fs.copyFileSync(src, path.join(bin, binary))
+  if (os !== "win32") fs.chmodSync(path.join(bin, binary), 0o755)
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        version: pkg.version,
+        license: pkg.license,
+        description: `${pkg.description} (${os} ${cpu} TUI binary)`,
+        files: ["bin/"],
+        os: [os],
+        cpu: [cpu],
+        publishConfig: { access: "public" },
+      },
+      null,
+      2,
+    ) + "\n",
+  )
+
+  const result = spawnSync("npm", ["pack", "--json"], { cwd: dir, encoding: "utf8" })
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout)
+  const packed = JSON.parse(result.stdout)[0].filename
+  fs.renameSync(path.join(dir, packed), path.join(out, packed))
+  console.log(path.join(out, packed))
+}

--- a/scripts/smoke-bootstrap-onboard.py
+++ b/scripts/smoke-bootstrap-onboard.py
@@ -203,8 +203,8 @@ def smoke_product_state_root_env() -> None:
                     "unsplash",
                 }:
                     raise RuntimeError("OpenSwarm Python path did not configure the generic add-ons JSON")
-                if "AGENTSWARM_PRODUCT_ENABLE_ADDONS" in os.environ:
-                    raise RuntimeError("OpenSwarm Python path still configured the legacy add-ons flag")
+                if os.environ.get("AGENTSWARM_PRODUCT_ENABLE_ADDONS") != "true":
+                    raise RuntimeError("OpenSwarm Python path did not enable AgentSwarm add-ons")
                 env.write_text(
                     'AGENTSWARM_BIN="/tmp/test-agentswarm"\nOPENAI_API_KEY="state-openai-updated"\n',
                     encoding="utf-8",
@@ -248,6 +248,110 @@ def smoke_product_state_root_env() -> None:
                 os.environ.pop("AGENTSWARM_BIN", None)
             else:
                 os.environ["AGENTSWARM_BIN"] = old_bin
+
+    with tempfile.TemporaryDirectory(prefix="openswarm-userbase-config-smoke-") as tmp:
+        base = Path(tmp).resolve()
+        module_dir = base / "site-packages"
+        prefix = base / "venv"
+        userbase = base / "user-base"
+        module_dir.mkdir()
+        prefix.mkdir()
+        userbase.mkdir()
+        (userbase / "openswarm.config.mjs").write_text(
+            (ROOT / "openswarm.config.mjs").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        (userbase / "openswarm.product-env.json").write_text(
+            (ROOT / "openswarm.product-env.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        (userbase / "package.json").write_text('{"version":"9.8.7-userbase"}\n', encoding="utf-8")
+
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_PRODUCT_VERSION") != "9.8.7-userbase":
+            raise RuntimeError("OpenSwarm Python path did not find fallback product config in site.USER_BASE without Node")
+        if values.get("AGENTSWARM_PRODUCT_DISPLAY_NAME") != "OpenSwarm":
+            raise RuntimeError("OpenSwarm Python path loaded wrong fallback product config from site.USER_BASE")
+
+
+def smoke_python_openswarm_tui_binary_resolution() -> None:
+    sys.path.insert(0, str(ROOT))
+    try:
+        import run_utils
+    finally:
+        sys.path.pop(0)
+
+    if run_utils._openswarm_package_names("linux", "x64", musl=True, baseline=True) != [
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl",
+        "@vrsen/openswarm-cli-linux-x64-musl",
+        "@vrsen/openswarm-cli-linux-x64-baseline",
+        "@vrsen/openswarm-cli-linux-x64",
+    ]:
+        raise RuntimeError("OpenSwarm Python path did not prefer linux x64 baseline musl packages")
+    if run_utils._openswarm_package_names("linux", "x64", musl=False, baseline=True) != [
+        "@vrsen/openswarm-cli-linux-x64-baseline",
+        "@vrsen/openswarm-cli-linux-x64",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl",
+        "@vrsen/openswarm-cli-linux-x64-musl",
+    ]:
+        raise RuntimeError("OpenSwarm Python path did not prefer linux x64 baseline glibc packages")
+    if run_utils._openswarm_package_names("linux", "arm64", musl=True, baseline=False) != [
+        "@vrsen/openswarm-cli-linux-arm64-musl",
+        "@vrsen/openswarm-cli-linux-arm64",
+    ]:
+        raise RuntimeError("OpenSwarm Python path did not include linux arm64 musl package fallback")
+    if run_utils._openswarm_package_names("windows", "x64", musl=False, baseline=True) != [
+        "@vrsen/openswarm-cli-windows-x64-baseline",
+        "@vrsen/openswarm-cli-windows-x64",
+    ]:
+        raise RuntimeError("OpenSwarm Python path did not prefer windows x64 baseline packages")
+
+    with tempfile.TemporaryDirectory(prefix="openswarm-python-tui-smoke-") as tmp:
+        root = Path(tmp).resolve()
+        package = root / "node_modules" / "@vrsen" / "openswarm-cli-linux-x64-baseline-musl" / "bin"
+        package.mkdir(parents=True)
+        binary = package / "agentswarm"
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        module_dir = root / "site-packages"
+        module_dir.mkdir()
+        state = root / "state"
+        state.mkdir()
+
+        old_bin = os.environ.pop("AGENTSWARM_BIN", None)
+        try:
+            with (
+                patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+                patch.object(run_utils.sys, "platform", "linux"),
+                patch.object(run_utils.platform_module, "machine", lambda: "x86_64"),
+                patch.object(run_utils, "_supports_avx2", lambda _platform, _arch: False),
+                patch.object(run_utils, "_is_musl", lambda: True),
+                patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(state)}, clear=False),
+            ):
+                run_utils._preload_agentswarm_bin(repo=module_dir)
+                if os.environ.get("AGENTSWARM_BIN") != str(binary):
+                    raise RuntimeError("OpenSwarm Python path did not preload the npm optional-package TUI binary")
+        finally:
+            if old_bin is None:
+                os.environ.pop("AGENTSWARM_BIN", None)
+            else:
+                os.environ["AGENTSWARM_BIN"] = old_bin
+
+    with (
+        patch.object(run_utils.sys, "platform", "win32"),
+        patch.object(run_utils.platform_module, "machine", lambda: "AMD64"),
+        patch.object(run_utils, "_supports_avx2", lambda _platform, _arch: False),
+        patch.object(run_utils, "_is_musl", lambda: False),
+    ):
+        specs = run_utils._openswarm_platform_packages()
+    if specs[0] != ("@vrsen/openswarm-cli-windows-x64-baseline", "agentswarm.exe"):
+        raise RuntimeError(f"OpenSwarm Python path did not use the Windows .exe binary name: {specs}")
 
 
 def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
@@ -392,11 +496,58 @@ def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
     if invoked != [(ROOT, "npm")]:
         raise RuntimeError(f"bootstrap did not invoke Node dependency setup for package.json: {invoked}")
 
+    with tempfile.TemporaryDirectory(prefix="openswarm-bootstrap-tui-smoke-") as tmp:
+        repo = Path(tmp).resolve()
+        repo.joinpath("package.json").write_text('{"dependencies":{}}\n', encoding="utf-8")
+        state = repo / "state"
+        state.mkdir()
+        binary = (
+            repo
+            / "node_modules"
+            / "@vrsen"
+            / "openswarm-cli-linux-x64-baseline-musl"
+            / "bin"
+            / "agentswarm"
+        )
+
+        def setup_node(repo: Path, npm: str) -> None:
+            invoked.append((repo, npm))
+            binary.parent.mkdir(parents=True)
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        old_bin = os.environ.pop("AGENTSWARM_BIN", None)
+        invoked.clear()
+        try:
+            with (
+                swapped_modules(replacements),
+                patch.object(run_utils, "__file__", str(repo / "run_utils.py")),
+                patch.object(run_utils.sys, "platform", "linux"),
+                patch.object(run_utils.platform_module, "machine", lambda: "x86_64"),
+                patch.object(run_utils, "_supports_avx2", lambda _platform, _arch: False),
+                patch.object(run_utils, "_is_musl", lambda: True),
+                patch.object(run_utils.shutil, "which", which),
+                patch.object(run_utils.subprocess, "check_call", lambda *_args, **_kwargs: None),
+                patch.object(run_utils, "_ensure_node_dependencies", setup_node),
+                patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(state)}, clear=False),
+            ):
+                run_utils._bootstrap()
+                if os.environ.get("AGENTSWARM_BIN") != str(binary):
+                    raise RuntimeError("bootstrap did not preload OpenSwarm TUI after npm optional-package setup")
+        finally:
+            if old_bin is None:
+                os.environ.pop("AGENTSWARM_BIN", None)
+            else:
+                os.environ["AGENTSWARM_BIN"] = old_bin
+
+    if invoked != [(repo, "npm")]:
+        raise RuntimeError(f"bootstrap did not run npm setup before post-bootstrap TUI preload: {invoked}")
+
 
 def main() -> int:
     smoke_swarm_import_skips_bootstrap()
     smoke_onboard_env_writes()
     smoke_product_state_root_env()
+    smoke_python_openswarm_tui_binary_resolution()
     smoke_bootstrap_node_setup_installs_slides_dependencies()
     print("OpenSwarm import bootstrap and onboarding smoke passed")
     return 0

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -2,124 +2,66 @@
 'use strict'
 
 const assert = require('assert')
-const EventEmitter = require('events')
+const cp = require('child_process')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const vm = require('vm')
+const { pathToFileURL } = require('url')
 
 const root = path.dirname(__dirname)
 const launcher = path.join(root, 'bin', 'openswarm')
+const configPath = path.join(root, 'openswarm.config.mjs')
+const productEnvPath = path.join(root, 'openswarm.product-env.json')
+const envWriter = path.join(root, 'scripts', 'write-product-env.mjs')
 
-function createClient(requests) {
-  return {
-    get(url, _opts, callback) {
-      requests.push(url)
-      const req = new EventEmitter()
-      req.setTimeout = () => req
-      req.destroy = (error) => req.emit('error', error)
+async function loadConfig() {
+  return import(pathToFileURL(configPath).href)
+}
 
-      process.nextTick(() => {
-        const res = new EventEmitter()
-        res.statusCode = 404
-        res.headers = {}
-        res.resume = () => {}
-        callback(res)
-      })
+function assertNoDownloadSource() {
+  const launcherSource = fs.readFileSync(launcher, 'utf8')
+  assert.equal(launcherSource.includes('http'), false, 'launcher still contains HTTP download code')
+  assert.equal(launcherSource.includes('OPENSWARM_TUI_URL'), false, 'launcher still reads OPENSWARM_TUI_URL')
 
-      return req
-    },
+  const runUtilsSource = fs.readFileSync(path.join(root, 'run_utils.py'), 'utf8')
+  assert.equal(runUtilsSource.includes('urlretrieve'), false, 'run_utils.py still downloads release assets')
+  assert.equal(runUtilsSource.includes('download=True'), false, 'run_utils.py still requests TUI binary downloads')
+  assert.equal(runUtilsSource.includes('releases/latest/download'), false, 'run_utils.py still references GitHub release downloads')
+}
+
+function assertPlatformDependencyVersions() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
+  const lock = JSON.parse(fs.readFileSync(path.join(root, 'package-lock.json'), 'utf8'))
+  assert.equal(lock.packages[''].version, pkg.version, 'package-lock root version does not match package.json')
+
+  const deps = Object.entries(pkg.optionalDependencies || {}).filter(([name]) => name.startsWith('@vrsen/openswarm-cli-'))
+  assert.equal(deps.length, 12, 'expected 12 OpenSwarm platform optional dependencies')
+
+  for (const [name, version] of deps) {
+    assert.equal(version, pkg.version, `${name} optionalDependency version must match package.json version`)
+    const entry = lock.packages[`node_modules/${name}`]
+    assert.ok(entry, `package-lock is missing ${name}`)
+    assert.equal(entry.version, pkg.version, `${name} package-lock version must match package.json version`)
+    assert.equal(entry.license, pkg.license, `${name} package-lock license must match package.json license`)
+    const unscoped = name.replace('@vrsen/', '')
+    const [, platform, arch] = unscoped.match(/^openswarm-cli-(darwin|linux|windows)-(arm64|x64)(?:-|$)/) || []
+    assert.ok(platform && arch, `${name} has unexpected platform package name`)
+    assert.deepEqual(entry.cpu, [arch], `${name} package-lock cpu is incomplete`)
+    assert.deepEqual(entry.os, [platform === 'windows' ? 'win32' : platform], `${name} package-lock os is incomplete`)
+    assert.equal(
+      entry.resolved,
+      `https://registry.npmjs.org/${name}/-/${unscoped}-${pkg.version}.tgz`,
+      `${name} package-lock resolved URL is incomplete`,
+    )
   }
 }
 
-function load(opts) {
-  const requests = []
-  const child = {
-    spawnSync(command) {
-      if (command === 'ldd') {
-        return {
-          status: 0,
-          stdout: opts.ldd || '',
-          stderr: '',
-        }
-      }
-      return {
-        status: 1,
-        stdout: '',
-        stderr: '',
-      }
-    },
-  }
-  const files = {
-    ...fs,
-    existsSync(target) {
-      if (target === '/etc/alpine-release') return Boolean(opts.alpine)
-      return fs.existsSync(target)
-    },
-  }
-  const proc = {
-    ...process,
-    arch: () => opts.arch,
-    env: {
-      ...process.env,
-      ...opts.env,
-    },
-    platform: opts.platform,
-    stdout: {
-      write() {},
-    },
-  }
-  const modules = {
-    assert,
-    events: EventEmitter,
-    fs: files,
-    http: createClient(requests),
-    https: createClient(requests),
-    os: {
-      arch: () => opts.arch,
-      homedir: () => opts.homedir || '/home/tester',
-    },
-    path,
-    'child_process': child,
-  }
-  const context = {
-    Buffer,
-    Error,
-    JSON,
-    Promise,
-    URL,
-    console,
-    module: { exports: {} },
-    process: proc,
-    require(name) {
-      if (modules[name]) return modules[name]
-      return require(name)
-    },
-    __filename: launcher,
-  }
-  context.exports = context.module.exports
+function assertProductAddons(env) {
+  assert.equal(env.AGENTSWARM_PRODUCT_ENABLE_ADDONS, 'true', 'AGENTSWARM_PRODUCT_ENABLE_ADDONS not enabled')
+  assert.ok(env.AGENTSWARM_PRODUCT_ADDONS, 'AGENTSWARM_PRODUCT_ADDONS not set')
 
-  const source = fs.readFileSync(launcher, 'utf8')
-  const start = source.startsWith('#!') ? source.indexOf('\n') + 1 : 0
-  const startup = source.indexOf('\nconst agentswarmBin = resolveAgentswarm(packageDir)')
-  assert.notEqual(startup, -1, 'launcher startup block not found')
-  const script = new vm.Script(
-    `${source.slice(start, startup)}
-module.exports = { downstreamEnv, getBinaryNames, isMuslLinux, resolveStateRoot, shouldUseDependencyBinary, ensureCustomBinary }`,
-    { filename: launcher },
-  )
-  script.runInNewContext(context)
-
-  return {
-    api: context.module.exports,
-    requests,
-  }
-}
-
-function assertProductAddons(api) {
-  assert.ok(api.downstreamEnv, 'downstreamEnv export not available')
-  assert.ok(api.downstreamEnv.AGENTSWARM_PRODUCT_ADDONS, 'AGENTSWARM_PRODUCT_ADDONS not set')
-
-  const addons = JSON.parse(api.downstreamEnv.AGENTSWARM_PRODUCT_ADDONS)
+  const addons = JSON.parse(env.AGENTSWARM_PRODUCT_ADDONS)
   assert.deepEqual(addons, [
     { id: 'search', title: 'Web Search', keys: ['SEARCH_API_KEY'] },
     { id: 'anthropic', title: 'Anthropic Claude', keys: ['ANTHROPIC_API_KEY'], excludeProviders: ['anthropic'] },
@@ -132,76 +74,268 @@ function assertProductAddons(api) {
   ])
 }
 
-function assertStateRoot() {
-  const linux = load({
-    platform: 'linux',
-    arch: 'x64',
-    homedir: '/home/tester',
-  })
-  assert.equal(linux.api.resolveStateRoot(), path.join('/home/tester', '.openswarm'))
-  assert.equal(linux.api.downstreamEnv.AGENTSWARM_PRODUCT_STATE_ROOT, path.join('/home/tester', '.openswarm'))
-
-  const darwin = load({
-    platform: 'darwin',
-    arch: 'arm64',
-    homedir: '/Users/tester',
-  })
-  assert.equal(darwin.api.resolveStateRoot(), path.join('/Users/tester', '.openswarm'))
-
-  const windows = load({
-    platform: 'win32',
-    arch: 'x64',
-    homedir: 'C:\\Users\\tester',
-    env: {
-      APPDATA: 'C:\\Users\\tester\\AppData\\Roaming',
+function loadLauncherResolver(opts) {
+  const source = fs.readFileSync(launcher, 'utf8').split('\nconst openswarmBinary = ')[0]
+  const fakeFs = {
+    ...fs,
+    existsSync(target) {
+      if (target === '/etc/alpine-release') return Boolean(opts.musl)
+      return fs.existsSync(target)
     },
-  })
-  assert.equal(windows.api.resolveStateRoot(), path.join('C:\\Users\\tester\\AppData\\Roaming', 'OpenSwarm'))
-
-  const explicit = load({
-    platform: 'linux',
-    arch: 'x64',
-    env: {
-      OPENSWARM_STATE_ROOT: '/tmp/openswarm-state',
+    readFileSync(target, encoding) {
+      if (target === '/proc/cpuinfo') return opts.avx2 ? 'flags\t: avx2\n' : 'flags\t: sse4_2\n'
+      return fs.readFileSync(target, encoding)
     },
+  }
+  const fakeChild = {
+    spawnSync(command) {
+      if (command === 'sysctl') {
+        return { status: 0, stdout: opts.avx2 ? '1\n' : '0\n', stderr: '' }
+      }
+      if (command === 'ldd') {
+        return { status: 0, stdout: opts.musl ? 'musl libc\n' : 'glibc\n', stderr: '' }
+      }
+      return { status: opts.avx2 ? 0 : 1, stdout: opts.avx2 ? 'True\n' : 'False\n', stderr: '' }
+    },
+  }
+  const sandbox = {
+    __filename: launcher,
+    console,
+    module: { exports: {} },
+    process: { ...process, arch: opts.arch, platform: opts.platform },
+    require(name) {
+      if (name === 'fs') return fakeFs
+      if (name === 'child_process') return fakeChild
+      if (name === 'path') return path
+      if (name === 'url') return require('url')
+      return require(name)
+    },
+  }
+  vm.runInNewContext(`${source}\nmodule.exports = { platformPackages, supportsAvx2, isMusl }`, sandbox, {
+    filename: launcher,
   })
-  assert.equal(explicit.api.resolveStateRoot(), path.resolve('/tmp/openswarm-state'))
+  return sandbox.module.exports
+}
+
+function assertPlatformPackageOrdering() {
+  const names = (opts) => loadLauncherResolver(opts).platformPackages().map((item) => item.name)
+
+  assert.deepEqual(names({ platform: 'linux', arch: 'x64', musl: true, avx2: false }), [
+    '@vrsen/openswarm-cli-linux-x64-baseline-musl',
+    '@vrsen/openswarm-cli-linux-x64-musl',
+    '@vrsen/openswarm-cli-linux-x64-baseline',
+    '@vrsen/openswarm-cli-linux-x64',
+  ])
+  assert.deepEqual(names({ platform: 'linux', arch: 'x64', musl: true, avx2: true }), [
+    '@vrsen/openswarm-cli-linux-x64-musl',
+    '@vrsen/openswarm-cli-linux-x64-baseline-musl',
+    '@vrsen/openswarm-cli-linux-x64',
+    '@vrsen/openswarm-cli-linux-x64-baseline',
+  ])
+  assert.deepEqual(names({ platform: 'linux', arch: 'x64', musl: false, avx2: false }), [
+    '@vrsen/openswarm-cli-linux-x64-baseline',
+    '@vrsen/openswarm-cli-linux-x64',
+    '@vrsen/openswarm-cli-linux-x64-baseline-musl',
+    '@vrsen/openswarm-cli-linux-x64-musl',
+  ])
+  assert.deepEqual(names({ platform: 'linux', arch: 'arm64', musl: true, avx2: false }), [
+    '@vrsen/openswarm-cli-linux-arm64-musl',
+    '@vrsen/openswarm-cli-linux-arm64',
+  ])
+  assert.deepEqual(names({ platform: 'darwin', arch: 'x64', musl: false, avx2: false }), [
+    '@vrsen/openswarm-cli-darwin-x64-baseline',
+    '@vrsen/openswarm-cli-darwin-x64',
+  ])
+  assert.deepEqual(names({ platform: 'darwin', arch: 'x64', musl: false, avx2: true }), [
+    '@vrsen/openswarm-cli-darwin-x64',
+    '@vrsen/openswarm-cli-darwin-x64-baseline',
+  ])
+  assert.deepEqual(names({ platform: 'win32', arch: 'x64', musl: false, avx2: false }), [
+    '@vrsen/openswarm-cli-windows-x64-baseline',
+    '@vrsen/openswarm-cli-windows-x64',
+  ])
+}
+
+async function assertStateRoot() {
+  const config = await loadConfig()
+  assert.equal(
+    config.resolveStateRoot({}, 'linux', '/home/tester'),
+    path.join('/home/tester', '.openswarm'),
+  )
+  assert.equal(
+    config.resolveStateRoot({}, 'darwin', '/Users/tester'),
+    path.join('/Users/tester', '.openswarm'),
+  )
+  assert.equal(
+    config.resolveStateRoot({ APPDATA: 'C:\\Users\\tester\\AppData\\Roaming' }, 'win32', 'C:\\Users\\tester'),
+    path.join('C:\\Users\\tester\\AppData\\Roaming', 'OpenSwarm'),
+  )
+  assert.equal(
+    config.resolveStateRoot({ OPENSWARM_STATE_ROOT: '/tmp/openswarm-state' }, 'linux', '/home/tester'),
+    path.resolve('/tmp/openswarm-state'),
+  )
+
+  const env = config.getProductEnv({
+    env: {},
+    stateRoot: path.join('/home/tester', '.openswarm'),
+    version: '1.2.3-test',
+  })
+  assert.equal(env.AGENTSWARM_PRODUCT_DISPLAY_NAME, 'OpenSwarm')
+  assert.equal(env.AGENTSWARM_PRODUCT_STATE_ROOT, path.join('/home/tester', '.openswarm'))
+  assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '1.2.3-test')
+  assertProductAddons(env)
+}
+
+async function assertProductEnvJsonSync() {
+  const config = await loadConfig()
+  const checkedIn = fs.readFileSync(productEnvPath, 'utf8')
+  const generated = cp.spawnSync(process.execPath, [envWriter, '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+  assert.equal(generated.status, 0, `env JSON writer exited with ${generated.status}: ${generated.stderr}`)
+  assert.equal(generated.stdout, checkedIn, 'write-product-env.mjs --json does not match openswarm.product-env.json')
+
+  const fallback = JSON.parse(checkedIn)
+  const env = config.getProductEnv({
+    env: {},
+    stateRoot: '__OPENSWARM_STATE_ROOT__',
+    version: '__OPENSWARM_VERSION__',
+  })
+  delete env.AGENTSWARM_PRODUCT_STATE_ROOT
+  delete env.AGENTSWARM_PRODUCT_VERSION
+  assert.deepEqual(fallback, env, 'openswarm.product-env.json is out of sync with openswarm.config.mjs')
+}
+
+function writeFakePackage(rootDir) {
+  const pkg = path.join(rootDir, 'node_modules', '@vrsen', 'openswarm')
+  const bin = path.join(pkg, 'bin')
+  const dep = path.join(pkg, 'node_modules', '@vrsen', 'agentswarm', 'bin')
+  const platform = path.join(pkg, 'node_modules', '@vrsen', `openswarm-cli-${process.platform === 'win32' ? 'windows' : process.platform}-${process.arch === 'arm64' ? 'arm64' : 'x64'}`, 'bin')
+  fs.mkdirSync(bin, { recursive: true })
+  fs.mkdirSync(dep, { recursive: true })
+  fs.mkdirSync(platform, { recursive: true })
+  fs.copyFileSync(launcher, path.join(bin, 'openswarm'))
+  fs.chmodSync(path.join(bin, 'openswarm'), 0o755)
+  fs.copyFileSync(configPath, path.join(pkg, 'openswarm.config.mjs'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify({ name: '@vrsen/openswarm', version: '7.8.9-smoke' }),
+    'utf8',
+  )
+  fs.writeFileSync(
+    path.join(dep, 'agentswarm'),
+    [
+      '#!/usr/bin/env node',
+      "'use strict'",
+      "const cp = require('child_process')",
+      "const fs = require('fs')",
+      "if (process.env.OPENSWARM_LAUNCHER_SMOKE_ENV) {",
+      "  fs.writeFileSync(process.env.OPENSWARM_LAUNCHER_SMOKE_ENV, JSON.stringify(process.env, null, 2))",
+      '}',
+      "const result = cp.spawnSync(process.env.AGENTSWARM_BIN_PATH, process.argv.slice(2), { stdio: 'inherit' })",
+      "process.exit(result.status ?? 1)",
+    ].join('\n'),
+    'utf8',
+  )
+  fs.chmodSync(path.join(dep, 'agentswarm'), 0o755)
+  fs.writeFileSync(
+    path.join(platform, process.platform === 'win32' ? 'agentswarm.exe' : 'agentswarm'),
+    [
+      '#!/usr/bin/env node',
+      "'use strict'",
+      "console.log('7.8.9-smoke')",
+    ].join('\n'),
+    'utf8',
+  )
+  fs.chmodSync(path.join(platform, process.platform === 'win32' ? 'agentswarm.exe' : 'agentswarm'), 0o755)
+  return path.join(bin, 'openswarm')
+}
+
+function assertLauncherDelegatesToDependency() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-smoke-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const envPath = path.join(tmp, 'env.json')
+    const result = cp.spawnSync(process.execPath, [bin, '--version'], {
+      cwd: tmp,
+      env: {
+        ...process.env,
+        OPENSWARM_TUI_URL: 'https://127.0.0.1:9/should-not-be-read',
+        OPENSWARM_LAUNCHER_SMOKE_ENV: envPath,
+      },
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
+    assert.equal(result.stdout.trim(), '7.8.9-smoke')
+
+    const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
+    assert.equal(env.AGENTSWARM_PRODUCT_DISPLAY_NAME, 'OpenSwarm')
+    assert.equal(env.AGENTSWARM_PRODUCT_COMMAND, 'openswarm')
+    assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
+    assert.equal(env.AGENTSWARM_LAUNCHER, '1')
+    assert.equal(env.PYTHONUTF8, '1')
+    assert.equal(env.PYTHONIOENCODING, 'utf-8')
+    assert.ok(env.AGENTSWARM_BIN_PATH, 'AGENTSWARM_BIN_PATH was not set')
+    assert.ok(env.AGENTSWARM_BIN_PATH.includes('openswarm-cli-'), 'AGENTSWARM_BIN_PATH did not use an OpenSwarm platform package')
+    assertProductAddons(env)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertMissingPlatformPackageFails() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-missing-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const pkg = path.join(tmp, 'node_modules', '@vrsen', 'openswarm', 'node_modules', '@vrsen')
+    for (const item of fs.readdirSync(pkg)) {
+      if (item.startsWith('openswarm-cli-')) fs.rmSync(path.join(pkg, item), { recursive: true, force: true })
+    }
+    const result = cp.spawnSync(process.execPath, [bin, '--version'], {
+      cwd: tmp,
+      encoding: 'utf8',
+    })
+    assert.notEqual(result.status, 0, 'launcher succeeded without an OpenSwarm platform package')
+    assert.ok(result.stderr.includes('optional dependencies enabled'), result.stderr)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertWorkflowEnvWriter() {
+  const result = cp.spawnSync(process.execPath, [envWriter], {
+    cwd: root,
+    env: {
+      ...process.env,
+      OPENSWARM_PRODUCT_VERSION: '4.5.6-workflow',
+    },
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, `env writer exited with ${result.status}: ${result.stderr}`)
+  assert.ok(result.stdout.includes('AGENTSWARM_PRODUCT_DISPLAY_NAME<<__OPENSWARM_ENV__'))
+  assert.ok(result.stdout.includes('OpenSwarm'))
+  assert.ok(result.stdout.includes('AGENTSWARM_PRODUCT_VERSION<<__OPENSWARM_ENV__'))
+  assert.ok(result.stdout.includes('4.5.6-workflow'))
+
+  const missing = cp.spawnSync(process.execPath, [envWriter], {
+    cwd: root,
+    env: Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'OPENSWARM_PRODUCT_VERSION' && key !== 'npm_package_version')),
+    encoding: 'utf8',
+  })
+  assert.notEqual(missing.status, 0, 'env writer succeeded without a product version')
+  assert.ok(missing.stderr.includes('OPENSWARM_PRODUCT_VERSION or npm_package_version is required'), missing.stderr)
 }
 
 async function main() {
-  const musl = load({
-    platform: 'linux',
-    arch: 'x64',
-    ldd: 'musl libc (x86_64)',
-  })
-  assert.equal(musl.api.isMuslLinux(), true)
-  assert.equal(musl.api.shouldUseDependencyBinary(), true)
-  assert.equal(await musl.api.ensureCustomBinary(), null)
-  assert.deepEqual(musl.requests, [])
-  assertProductAddons(musl.api)
-  assertStateRoot()
-
-  const explicit = load({
-    platform: 'linux',
-    arch: 'x64',
-    env: {
-      OPENSWARM_TUI_URL: 'https://example.test/openswarm',
-    },
-    ldd: 'musl libc (x86_64)',
-  })
-  assert.equal(explicit.api.shouldUseDependencyBinary(), false)
-  assert.deepEqual(explicit.api.getBinaryNames(), ['agentswarm-linux-x64', 'agentswarm-linux-x64-baseline'])
-
-  const glibc = load({
-    platform: 'linux',
-    arch: 'x64',
-    ldd: 'ldd (GNU libc)',
-  })
-  assert.equal(glibc.api.isMuslLinux(), false)
-  assert.equal(glibc.api.shouldUseDependencyBinary(), false)
-  await assert.rejects(() => glibc.api.ensureCustomBinary(), /custom OpenSwarm TUI unavailable/)
-  assert.ok(glibc.requests.some((url) => url.includes('agentswarm-linux-x64')))
-
+  assertNoDownloadSource()
+  assertPlatformDependencyVersions()
+  assertPlatformPackageOrdering()
+  await assertStateRoot()
+  await assertProductEnvJsonSync()
+  assertLauncherDelegatesToDependency()
+  assertMissingPlatformPackageFails()
+  assertWorkflowEnvWriter()
   console.log('openswarm launcher smoke passed')
 }
 

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -102,8 +102,17 @@ def platform_asset_name() -> str:
     )
 
 
+def platform_package_name() -> str:
+    asset = platform_asset_name()
+    if asset.endswith(".exe"):
+        asset = asset[:-4]
+    return asset.replace("agentswarm-", "@vrsen/openswarm-cli-", 1)
+
+
 def install_openswarm_tui_binary(package_dir: pathlib.Path, binary: pathlib.Path) -> pathlib.Path:
-    target = package_dir / platform_asset_name()
+    executable = "agentswarm.exe" if sys.platform == "win32" else "agentswarm"
+    target = package_dir / "node_modules" / pathlib.Path(*platform_package_name().split("/")) / "bin" / executable
+    target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(binary, target)
     if os.name != "nt":
         target.chmod(target.stat().st_mode | 0o111)

--- a/scripts/write-product-env.mjs
+++ b/scripts/write-product-env.mjs
@@ -1,0 +1,32 @@
+import { getProductEnv } from "../openswarm.config.mjs"
+
+function stableProductEnv() {
+  const env = getProductEnv({
+    stateRoot: "__OPENSWARM_STATE_ROOT__",
+    version: "__OPENSWARM_VERSION__",
+  })
+  delete env.AGENTSWARM_PRODUCT_STATE_ROOT
+  delete env.AGENTSWARM_PRODUCT_VERSION
+  return env
+}
+
+if (process.argv.includes("--json")) {
+  console.log(JSON.stringify(stableProductEnv(), null, 2))
+  process.exit(0)
+}
+
+const version = process.env.OPENSWARM_PRODUCT_VERSION || process.env.npm_package_version
+if (!version) {
+  console.error("OPENSWARM_PRODUCT_VERSION or npm_package_version is required to write OpenSwarm product env.")
+  process.exit(1)
+}
+
+const env = getProductEnv({ version })
+
+for (const [key, value] of Object.entries(env)) {
+  if (key === "AGENTSWARM_PRODUCT_STATE_ROOT") continue
+  if (value === undefined) continue
+  console.log(`${key}<<__OPENSWARM_ENV__`)
+  console.log(value)
+  console.log("__OPENSWARM_ENV__")
+}


### PR DESCRIPTION
## Summary
- Adds `openswarm.config.mjs` as the single editable OpenSwarm product config source.
- Generates a synced JSON fallback for Python/no-Node paths.
- Changes OpenSwarm npm install behavior to use platform optional packages instead of runtime GitHub binary downloads.
- Updates build, publish, and smoke workflows for the npm/npx package path.

## Checks
- Local launcher, Python bootstrap, platform package, packed install, no-Node fallback, lockfile, and workflow syntax checks passed.
- Local Codex review found no actionable correctness issues.
