### PR TITLE
chore: prepare OpenSwarm rc8

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AGENTSWARM_CLI_VERSION: 1.4.37-rc.1
+  AGENTSWARM_CLI_VERSION: 1.4.38
 
 jobs:
   prepare:

--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
-          ref: v1.4.37-rc.1
+          ref: v1.4.38
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: VRSEN/agentswarm-cli
-          ref: v1.4.37-rc.1
+          ref: v1.4.38
           path: agentswarm-cli
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*$py.class
+node_modules/
+.venv/
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.7",
+    "version": "1.0.1-rc.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.7",
+            "version": "1.0.1-rc.8",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.37-rc.1",
+                "@vrsen/agentswarm": "1.4.38",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -31,18 +31,18 @@
                 "python": ">=3.10"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.7",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.7"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.8",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.8"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -510,21 +510,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.37-rc.1.tgz",
-            "integrity": "sha512-MMhFLgwvzirgYfxjlwch5Ig+rLGWF2Jvgc3h0U3/F+R2miyGCXLI9sfaIXbhnuNLAwv+celEA+0GLPMuwLdxCg==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.38.tgz",
+            "integrity": "sha512-fig4KxAS6cNlJwAtoltmP3j9yuoxx6KaDtPzHsREEMCm+QGti93fqHSP3wYKFOqj9QeGC4b6U02dr8yCYwPNWg==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.37-rc.1"
+                "agentswarm-cli": "1.4.38"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-M+T6PgHLlVG8Ja3HPedwlPHp4pioO/JoAYMLyR+zO3RSdPHPSCt4eDRORZW4krimenkVRKyeXsPSS0aXTm8AGg==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.38.tgz",
+            "integrity": "sha512-wVOLMiMd62IMPfgFjotdteaSCqPWghFgoemplK0jcW+1u1lbahyKCF7JY/IjO1SVjjyyoij+uoMky1bXfVsMtg==",
             "cpu": [
                 "arm64"
             ],
@@ -534,9 +534,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-LOOcMyqprR2P6oSo+gd0URBzOVTWYq0KljS4Wt5QbMm6QH7S+xKXBZsQs+K3yvvCd2tBNvGtfQJDuA8JeNr9Xw==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.38.tgz",
+            "integrity": "sha512-p+w4X5LO4MHyaGqjFaoT2wV/eNlIN9Z/4eATimmW1U+TVQnWWht7mnzN19iIROocvhZO9i7KEasuwact2lXUGA==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.37-rc.1.tgz",
-            "integrity": "sha512-l23XO8hW7MK7MxwNpqU31BjWtGR0hM7y5Yfdv+QsFNm6HDYzfl9wqT/dywMTwj7SaVwOfR26LlIkM6jCl7538Q==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.38.tgz",
+            "integrity": "sha512-SzsyHKoooMK1BGi7V4UWBG4SOLPnrYwFVC8a2luC2B9BNlpIZ8RIsJ0nFz2VH8/hPQrIGJULZkuUOs9JbDo22A==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-EKt/QSHw6uVfUOoF5ZdvImDFcPjZcTbSB/j46z/4Rw7Vs/SV4odnXKj557uG9rffDIGGZA2/vZlGUuu+PqWGYw==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.38.tgz",
+            "integrity": "sha512-4+p+9tdy/rkRqAvrXeXBOW3yrpFGIUwEBJx9oDSdXoM7OTmpAqirk/0/N2v3oqabOVBlrHJ20BYcfC+v31Rqfw==",
             "cpu": [
                 "arm64"
             ],
@@ -570,9 +570,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.37-rc.1.tgz",
-            "integrity": "sha512-td37WAQc8FWIZL0lncOElVqv3ub1kIBVbV0KHDpXqdw4Ergw0LDQhcuKZUTGVtW6TDGMC0+99kduDwKlsrvA6A==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.38.tgz",
+            "integrity": "sha512-hS7YoT7NzQSr8B61HRi8JaFe9OMgHQYz0F5on0L3AkHQgFmDAZHliJ5h+r8yG5xpdGY+8WTEC4CK+g0IFXW2fA==",
             "cpu": [
                 "arm64"
             ],
@@ -582,9 +582,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-EJnrrcJxCrMFW/058SzQsJ1wOneD8+dz82vE3Patvnuy2y+7WugwePJ1hOoau5rk07HVpiy0qozsHjcVqQuB3g==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.38.tgz",
+            "integrity": "sha512-YsmyXLbfez4OOwfP7h/2PrwjqhYlFftHpu210RIhxbVnGkKSFIQsdZUfEC0qa+xqiW03B/vPI4AIEw1NUL8MOg==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.37-rc.1.tgz",
-            "integrity": "sha512-X1CzMTnaRR8rjHJs2ddvMqznhpQDBk4QjbIcnYIJTms1MktaukskwL9v1u3cpJjjGoQR43nsJHS169KsAEe+Tg==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.38.tgz",
+            "integrity": "sha512-RvDotmljiWgXUiJMoSc2a6vzTvHrmJwsuJkURs+VOi1eO74jnzkIjCZ/T/SoGtOg10ybfHjE10dXFFdjXDjCvw==",
             "cpu": [
                 "x64"
             ],
@@ -606,9 +606,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.37-rc.1.tgz",
-            "integrity": "sha512-VEqcy5fUbt74UQhF+7JtJMzPvjDmWqWXfQns9Iks71RvJ5pbQkp7hkdMU6uQyyuvjj+2abCpwIh2mfHHSXIwNw==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.38.tgz",
+            "integrity": "sha512-bT0wmyfvLMzS7+OVDSdvZOCaKvlXTf6FGIVNJYuulSEjx8z0CwxqSzA8b20r1UgXC5wqVPAADlYG95vRevQaqQ==",
             "cpu": [
                 "x64"
             ],
@@ -618,9 +618,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.37-rc.1.tgz",
-            "integrity": "sha512-q1VFL5XgOZfapFE0aEi4fGMJZce0uN7QXzehw+BhKnQi4xW9UVzpA+kieXzOga+MH0pQJCSMy6Qct3c3MbT4Fw==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.38.tgz",
+            "integrity": "sha512-dSWDpO6bAnN73ubandTx7U2lDGwbTmzhPaZ7UNmU8L4gb6j3DhyLTM2dbRsFdBHd8Po3PDPJH1vMy0EcyfRbdA==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +630,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-SuBMCcjqJEFnDa1LN+RL3kRveGudcrr0lNs6qwGiBJN9xPnbGrqysi8A9ThyWbhHXbbFJf5mbBYBL1Ru0hVdwQ==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.38.tgz",
+            "integrity": "sha512-eUCu+XqAB6wOwYvsEUVJb6wWr8FPu//hpYBnQSc760/BOWGJ/d/7h5mUs1NEFYfYr7OIoD+QWfKLrowNwYN0Bg==",
             "cpu": [
                 "arm64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.37-rc.1.tgz",
-            "integrity": "sha512-kPeB6uxyRFJYgFmuz4MBiVXmeXXxDdWs/zCDuVKh3LkOjcOtaqND3A8GVPdavBgOrEV6K5B8aeIybIXAI7qD9A==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.38.tgz",
+            "integrity": "sha512-pZlfHisR8e7n8lAhaJRCu6P70KcUiJe9B0P4vpRbM76Tz7UX+eau1Ds1UE6w5Z06ddCySaoJS9CgO4kyM8p4HQ==",
             "cpu": [
                 "x64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.37-rc.1.tgz",
-            "integrity": "sha512-UphkBJ+d28WN/tzA+d4b0K6KDNhNY5pqFMaYDiAoETUUFaltzG3pXEudqH+dmdpjHgDkkGhQV6srAoQ6bA8ntg==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.38.tgz",
+            "integrity": "sha512-qdvkPY0w8mi96CDat3SXCpQKwLSUZlKzMyeRql00jRnLWzKYUuPYfuz6PLWpPBpNm1IzzffepdIR+K2HvOA9pQ==",
             "cpu": [
                 "x64"
             ],
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.0.1-rc.7",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.7.tgz",
+            "version": "1.0.1-rc.8",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.8.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -825,27 +825,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.37-rc.1",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.37-rc.1.tgz",
-            "integrity": "sha512-I9j41zn5qViawRuu4qVQam9EdcNyrlBOnVennkJG8s7P66xVVueSgFCT0v6m8hACSOIPeXOL8k1E+UUvWtw9ow==",
+            "version": "1.4.38",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.38.tgz",
+            "integrity": "sha512-o0M2rWFSL3heL+eiwZjpkBA5huBOJBkjIIXzny7FHORsC6sXZM93zPpwHQdUlsx6ogYKXv0f6cYU3kNb8o7wPA==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.37-rc.1",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.37-rc.1"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.38",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.38",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.38",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.38",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.38",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.38",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.38"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.7",
+    "version": "1.0.1-rc.8",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -32,13 +32,16 @@
         "patches/",
         "pyproject.toml",
         "package.json",
-        "package-lock.json"
+        "package-lock.json",
+        "!**/__pycache__/**",
+        "!**/*.pyc",
+        "!node_modules/**"
     ],
     "scripts": {
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.37-rc.1",
+        "@vrsen/agentswarm": "1.4.38",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
@@ -49,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.7",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.7"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.8",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.8"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/patches/patch_agency_swarm_dual_comms.py
+++ b/patches/patch_agency_swarm_dual_comms.py
@@ -14,20 +14,64 @@ from __future__ import annotations
 from typing import Any
 
 
+def _validate_communication_tool_class(tool_class: type, send_message_class: type, handoff_class: type) -> None:
+    if not issubclass(tool_class, (send_message_class, handoff_class)):
+        raise TypeError(
+            f"Invalid communication tool class: {tool_class.__name__}. "
+            "Expected a SendMessage or Handoff subclass."
+        )
+
+
 def _add_tool_class_for_pair(
     mapping: dict[tuple[str, str], list[type]],
+    default_tool_pairs: set[tuple[str, str]],
     pair_key: tuple[str, str],
     tool_class: type | None,
+    send_message_class: type,
+    handoff_class: type,
 ) -> None:
     if tool_class is None:
         return
+    _validate_communication_tool_class(tool_class, send_message_class, handoff_class)
+    if pair_key in default_tool_pairs and issubclass(tool_class, send_message_class):
+        raise ValueError(
+            f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+            f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+        )
     classes = mapping.setdefault(pair_key, [])
+    if issubclass(tool_class, send_message_class):
+        for existing_tool_class in classes:
+            if issubclass(existing_tool_class, send_message_class):
+                raise ValueError(
+                    f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+                    f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+                )
     if tool_class in classes:
         raise ValueError(
             f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
             f"{tool_class.__name__}. Each tool class for a pair can only be defined once."
         )
     classes.append(tool_class)
+
+
+def _add_default_tool_pair(
+    custom_mapping: dict[tuple[str, str], list[type]],
+    default_tool_pairs: set[tuple[str, str]],
+    pair_key: tuple[str, str],
+    send_message_class: type,
+) -> None:
+    if pair_key in default_tool_pairs:
+        raise ValueError(
+            f"Duplicate communication flow detected: {pair_key[0]} -> {pair_key[1]}. "
+            "Each default agent-to-agent communication can only be defined once."
+        )
+    for tool_class in custom_mapping.get(pair_key, []):
+        if issubclass(tool_class, send_message_class):
+            raise ValueError(
+                f"Duplicate communication tool class detected for {pair_key[0]} -> {pair_key[1]}: "
+                f"{tool_class.__name__}. Each SendMessage tool for a pair can only be defined once."
+            )
+    default_tool_pairs.add(pair_key)
 
 
 def apply_dual_comms_patch() -> None:
@@ -44,9 +88,10 @@ def apply_dual_comms_patch() -> None:
 
     def parse_agent_flows_patched(
         agency: Any, communication_flows: list[Any]
-    ) -> tuple[list[tuple[Agent, Agent]], dict[tuple[str, str], list[type]]]:
+    ) -> tuple[list[tuple[Agent, Agent]], dict[tuple[str, str], list[type]], set[tuple[str, str]]]:
         basic_flows: list[tuple[Agent, Agent]] = []
         tool_class_mapping: dict[tuple[str, str], list[type]] = {}
+        default_tool_pairs: set[tuple[str, str]] = set()
         seen_flows: set[tuple[str, str]] = set()
 
         chain_flows = AgentFlow.get_and_clear_chain_flows()
@@ -61,13 +106,10 @@ def apply_dual_comms_patch() -> None:
 
                 if isinstance(first, Agent) and isinstance(second, Agent):
                     flow_key = (first.name, second.name)
-                    if flow_key in seen_flows:
-                        raise ValueError(
-                            f"Duplicate communication flow detected: {first.name} -> {second.name}. "
-                            "Each agent-to-agent communication can only be defined once."
-                        )
-                    seen_flows.add(flow_key)
-                    basic_flows.append((first, second))
+                    if flow_key not in seen_flows:
+                        seen_flows.add(flow_key)
+                        basic_flows.append((first, second))
+                    _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key, SendMessage)
 
                 elif isinstance(first, AgentFlow) and (isinstance(second, type) or second is None):
                     tool_class = second
@@ -84,12 +126,19 @@ def apply_dual_comms_patch() -> None:
                             seen_flows.add(flow_key)
                             basic_flows.append((sender, receiver))
                         elif tool_class is None:
-                            raise ValueError(
-                                f"Duplicate communication flow detected: {sender.name} -> {receiver.name}. "
-                                "Each agent-to-agent communication can only be defined once unless adding "
-                                "a distinct tool class."
+                            _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key, SendMessage)
+                            continue
+                        if tool_class is None:
+                            _add_default_tool_pair(tool_class_mapping, default_tool_pairs, flow_key, SendMessage)
+                        else:
+                            _add_tool_class_for_pair(
+                                tool_class_mapping,
+                                default_tool_pairs,
+                                flow_key,
+                                tool_class,
+                                SendMessage,
+                                Handoff,
                             )
-                        _add_tool_class_for_pair(tool_class_mapping, flow_key, tool_class)
                 else:
                     raise TypeError(
                         f"Invalid communication flow entry: {flow_entry}. "
@@ -105,6 +154,8 @@ def apply_dual_comms_patch() -> None:
                 # The agency factory reconstructs flows from _communication_tool_classes,
                 # which stores lists of types per pair. Accept both a single class and a list.
                 tool_classes = tool_class if isinstance(tool_class, (list, tuple)) else [tool_class]
+                if not tool_classes:
+                    raise ValueError("Communication flow tool class list cannot be empty.")
                 for tc in tool_classes:
                     if not isinstance(tc, type):
                         raise TypeError(f"Invalid tool class in communication flow: {tc}. Expected a class type.")
@@ -115,12 +166,12 @@ def apply_dual_comms_patch() -> None:
                     basic_flows.append((sender, receiver))
 
                 for tc in tool_classes:
-                    _add_tool_class_for_pair(tool_class_mapping, flow_key, tc)
+                    _add_tool_class_for_pair(tool_class_mapping, default_tool_pairs, flow_key, tc, SendMessage, Handoff)
 
             else:
                 raise ValueError(f"Invalid communication flow entry: {flow_entry}. Expected 2 or 3 elements.")
 
-        return basic_flows, tool_class_mapping
+        return basic_flows, tool_class_mapping, default_tool_pairs
 
     def configure_agents_patched(agency: Any, defined_communication_flows: list[tuple[Agent, Agent]]) -> None:
         setup_mod.logger.info("Configuring agents...")
@@ -137,15 +188,26 @@ def apply_dual_comms_patch() -> None:
             allowed_recipients = communication_map.get(agent_name, [])
 
             if allowed_recipients:
+                if not agent_instance.supports_outbound_communication:
+                    joined = ", ".join(allowed_recipients)
+                    raise ValueError(
+                        f"Agent '{agent_name}' cannot be the sender in communication_flows. "
+                        f"It can receive delegated work, but it cannot delegate to: {joined}."
+                    )
                 setup_mod.logger.debug(f"Agent '{agent_name}' can send messages to: {allowed_recipients}")
                 for recipient_name in allowed_recipients:
                     recipient_agent = agency.agents[recipient_name]
                     pair_key = (agent_name, recipient_name)
                     configured = agency._communication_tool_classes.get(pair_key, [])
-                    tool_classes = list(configured) if configured else [agency.send_message_tool_class or SendMessage]
+                    tool_classes: list[type] = []
+                    if pair_key in agency._default_communication_tool_pairs:
+                        tool_classes.append(agency.send_message_tool_class or SendMessage)
+                    tool_classes.extend(configured)
+                    if not tool_classes:
+                        tool_classes.append(agency.send_message_tool_class or SendMessage)
 
-                    try:
-                        for effective_tool_class in tool_classes:
+                    for effective_tool_class in tool_classes:
+                        try:
                             if isinstance(effective_tool_class, Handoff) or (
                                 isinstance(effective_tool_class, type) and issubclass(effective_tool_class, Handoff)
                             ):
@@ -162,6 +224,7 @@ def apply_dual_comms_patch() -> None:
                                     setup_mod._warned_deprecated_send_message_handoff = True
 
                                 handoff_instance = effective_tool_class().create_handoff(recipient_agent=recipient_agent)
+                                handoff_instance._agency_swarm_tool_class = effective_tool_class
                                 runtime_state.handoffs.append(handoff_instance)
                                 setup_mod.logger.debug(f"Added Handoff for {agent_name} -> {recipient_name}")
                             else:
@@ -174,11 +237,11 @@ def apply_dual_comms_patch() -> None:
                                     send_message_tool_class=chosen_tool_class,
                                     runtime_state=runtime_state,
                                 )
-                    except Exception as e:
-                        setup_mod.logger.error(
-                            f"Error registering subagent '{recipient_name}' for sender '{agent_name}': {e}",
-                            exc_info=True,
-                        )
+                        except Exception as e:
+                            setup_mod.logger.error(
+                                f"Error registering subagent '{recipient_name}' for sender '{agent_name}': {e}",
+                                exc_info=True,
+                            )
             else:
                 setup_mod.logger.debug(f"Agent '{agent_name}' has no explicitly defined outgoing communication paths.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"
 dependencies = [
-    "agency-swarm[fastapi,jupyter,litellm]>=1.9.8",
+    "agency-swarm[fastapi,jupyter,litellm]>=1.10.0",
     "questionary>=2.0.0",
     "python-dotenv",
     "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.7"
+version = "1.0.1-rc.8"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agency-swarm[fastapi,jupyter,litellm]>=1.9.7
+agency-swarm[fastapi,jupyter,litellm]>=1.10.0
 questionary>=2.0.0
 fastapi
 uvicorn

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -119,8 +119,8 @@ def install_openswarm_tui_binary(package_dir: pathlib.Path, binary: pathlib.Path
     return target
 
 
-def create_local_openswarm_project(package_dir: pathlib.Path, root: pathlib.Path) -> pathlib.Path:
-    target = root / "openswarm"
+def create_local_openswarm_project(package_dir: pathlib.Path, root: pathlib.Path, name: str = "openswarm") -> pathlib.Path:
+    target = root / name
     ignore = shutil.ignore_patterns(
         ".git",
         ".venv",
@@ -174,6 +174,14 @@ def write(fd: int, text: str) -> None:
 
 def compact(text: str) -> str:
     return re.sub(r"\s+", "", text)
+
+
+def is_run_mode_ready(plain: str) -> bool:
+    packed = compact(plain).lower()
+    has_current_footer = "run·swarmdefault" in packed or "runswarmdefault" in packed
+    has_command_ui = "tabagents" in packed and "ctrl+pcommands" in packed
+    has_legacy_footer = "agencyswarmdefault" in packed
+    return has_command_ui and (has_current_footer or has_legacy_footer)
 
 
 def terminate(process: subprocess.Popen[bytes]) -> None:
@@ -306,7 +314,7 @@ def run_tui_smoke(
                 write(master_fd, "\r")
                 sent_confirm = True
 
-            run_mode_ready = "AgencySwarmDefault" in compact_plain and "ctrl+pcommands" in compact_plain
+            run_mode_ready = is_run_mode_ready(plain)
 
             if check in {"agents", "all"} and not sent_agents_command and run_mode_ready:
                 write(master_fd, "/agents\r")
@@ -398,7 +406,9 @@ def run_tui_smoke(
             if selected_models_command and not verified_models:
                 models_picker = compact(plain[models_picker_start:]).lower()
                 if "selectmodel" in models_picker and (
-                    "agencyswarmdefault" in models_picker or "manageproviderauth" in models_picker
+                    "swarmdefault" in models_picker
+                    or "agencyswarmdefault" in models_picker
+                    or "manageproviderauth" in models_picker
                 ):
                     verified_models = True
                     write(master_fd, "\x1b")
@@ -479,6 +489,7 @@ def main() -> int:
         raise RuntimeError("OPENAI_API_KEY is required for the live prompt smoke test")
     auth_key = api_key or "dummy-openai-key-for-agent-roster-smoke"
     root = pathlib.Path(tempfile.mkdtemp(prefix="openswarm-run-mode-smoke-"))
+    state_root = root / "openswarm-state"
     env = os.environ.copy()
     env.update(
         {
@@ -491,6 +502,7 @@ def main() -> int:
             "XDG_CONFIG_HOME": str(root / "xdg-config"),
             "XDG_CACHE_HOME": str(root / "xdg-cache"),
             "XDG_STATE_HOME": str(root / "xdg-state"),
+            "OPENSWARM_STATE_ROOT": str(state_root),
             "OPENCODE_DISABLE_AUTOUPDATE": "true",
             "OPENCODE_DISABLE_MODELS_FETCH": "true",
         }
@@ -517,10 +529,11 @@ def main() -> int:
             ),
             encoding="utf-8",
         )
-        project_dir = create_local_openswarm_project(package_dir, generic_dir)
+        state_root.mkdir(parents=True, exist_ok=True)
+        project_dir = create_local_openswarm_project(package_dir, state_root, "project")
         plain = run_tui_smoke(launcher, package_dir, project_dir, root, env, args.check, args.prompt, args.expect, args.timeout)
-        if "Agency Swarm Default" not in plain:
-            raise RuntimeError("Smoke response was seen, but Agency Swarm Run mode was not detected")
+        if not is_run_mode_ready(plain):
+            raise RuntimeError("Smoke response was seen, but OpenSwarm Run mode and command UI were not detected")
         if args.check in {"agents", "all"}:
             print(f"OpenSwarm /agents smoke passed with {EXPECTED_AGENT_COUNT} agents visible")
         if args.check in {"models", "all"}:


### PR DESCRIPTION
## Summary
- prepare OpenSwarm `v1.0.1-rc.8` around the product-config launcher and package path
- require Agency Swarm 1.10 so OpenSwarm's communication patch matches the current handoff and `SendMessage` shape
- refresh model availability, package metadata, bytecode exclusions, and run-mode smoke coverage

## Verification
- `node scripts/smoke-openswarm-launcher.js`
- `python3 scripts/smoke-bootstrap-onboard.py`
- `python3 scripts/smoke-wheel-bootstrap.py`
- `npm pack --dry-run --json` -> `vrsen-openswarm-1.0.1-rc.8.tgz`, 205 files, no `node_modules`, `__pycache__`, or `.pyc`
- OpenSwarm-branded TUI QA passed `/models`, `/agents`, live OpenRouter prompt, and live OpenRouter handoff follow-up
- Handoff schema proof: `scripts/smoke-run-mode.py --check handoff` re-verified required OpenAI tool schema constraints for handoff and `SendMessage`
