### PR TITLE
fix: publish OpenSwarm platform tarballs as files

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -409,7 +409,7 @@ jobs:
               echo "Skipping $pkg_id; already published."
               continue
             fi
-            npm publish "$package" --access public --tag "$NPM_TAG"
+            npm publish "./$package" --access public --tag "$NPM_TAG"
           done
 
       - name: Publish npm package

--- a/.github/workflows/publish-npm-on-release.yml
+++ b/.github/workflows/publish-npm-on-release.yml
@@ -128,7 +128,7 @@ jobs:
               echo "Skipping $pkg_id; already published."
               continue
             fi
-            npm publish "$package" --access public --tag "$NPM_TAG"
+            npm publish "./$package" --access public --tag "$NPM_TAG"
           done
 
       - name: Publish npm package


### PR DESCRIPTION
## Summary
- prefix generated platform tarball paths with `./` before `npm publish`
- keep the fallback release publish workflow aligned with the main release workflow

## Verification
- `git diff --check`
- `npm publish --dry-run ./platform-packages/does-not-exist.tgz` resolves as `file:platform-packages/...` and fails with local ENOENT, not GitHub shortcut lookup