### PR TITLE
chore(release): prepare OpenSwarm 1.0.1-rc.9

### DIFF
--- a/.github/workflows/build-tui.yml
+++ b/.github/workflows/build-tui.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  AGENTSWARM_CLI_VERSION: 1.4.38
+  AGENTSWARM_CLI_VERSION: 1.4.39
 
 jobs:
   prepare:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.8",
+    "version": "1.0.1-rc.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.8",
+            "version": "1.0.1-rc.9",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.38",
+                "@vrsen/agentswarm": "1.4.39",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -31,18 +31,18 @@
                 "python": ">=3.10"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.8",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.8"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.9",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.9"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -510,21 +510,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.38.tgz",
-            "integrity": "sha512-fig4KxAS6cNlJwAtoltmP3j9yuoxx6KaDtPzHsREEMCm+QGti93fqHSP3wYKFOqj9QeGC4b6U02dr8yCYwPNWg==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.39.tgz",
+            "integrity": "sha512-AUA/5jU6pj2PB/h5C8AeibUUa6zo9MhxrnY32zQy4y1piqOFsI4OERLX9m09egzMuTgjdQkn57waZM0fLdeY5Q==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.38"
+                "agentswarm-cli": "1.4.39"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.38.tgz",
-            "integrity": "sha512-wVOLMiMd62IMPfgFjotdteaSCqPWghFgoemplK0jcW+1u1lbahyKCF7JY/IjO1SVjjyyoij+uoMky1bXfVsMtg==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.39.tgz",
+            "integrity": "sha512-jge2/vH9rS4Ouu4VYDz0vG+EM+Fb3uukNn+haWI0SRIeRIgoO0HOSEamJ0EO7XZhTQOdIqO5heYvm7Y9xNCcdA==",
             "cpu": [
                 "arm64"
             ],
@@ -534,9 +534,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.38.tgz",
-            "integrity": "sha512-p+w4X5LO4MHyaGqjFaoT2wV/eNlIN9Z/4eATimmW1U+TVQnWWht7mnzN19iIROocvhZO9i7KEasuwact2lXUGA==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.39.tgz",
+            "integrity": "sha512-GBIclRM+jKWz9RJ8orFNGYptF2k3Omg2hdCGjWOG5ey1iVAkMm/FNf0LBkmh8l341zYFVRnUGYTezphdvI9aJA==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.38.tgz",
-            "integrity": "sha512-SzsyHKoooMK1BGi7V4UWBG4SOLPnrYwFVC8a2luC2B9BNlpIZ8RIsJ0nFz2VH8/hPQrIGJULZkuUOs9JbDo22A==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.39.tgz",
+            "integrity": "sha512-fFDDYVuh28tmynC91nnyCJFzz3K0gRcMQy6S5bExQG2TadlCOGxKfkKAv4eUM63A5Hu48b/OpQWiocL2mE12Xg==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.38.tgz",
-            "integrity": "sha512-4+p+9tdy/rkRqAvrXeXBOW3yrpFGIUwEBJx9oDSdXoM7OTmpAqirk/0/N2v3oqabOVBlrHJ20BYcfC+v31Rqfw==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.39.tgz",
+            "integrity": "sha512-iMte86kLfXn9wvxojAoT9XHKMtgG1gI1HxpzQ5tJTMgp86sWUjM3EozGQp8sZMK9E4PK/fAZTGJwqymP25tPvw==",
             "cpu": [
                 "arm64"
             ],
@@ -570,9 +570,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.38.tgz",
-            "integrity": "sha512-hS7YoT7NzQSr8B61HRi8JaFe9OMgHQYz0F5on0L3AkHQgFmDAZHliJ5h+r8yG5xpdGY+8WTEC4CK+g0IFXW2fA==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.39.tgz",
+            "integrity": "sha512-GP5+LsnEA1sdhR6tv1HcYTFD0yA8LlYBOEZGbKY+XBx9lg+IHQ44N4fKaQ7GSJ3g10Kq/S+gIZHO0aESjMX2Kw==",
             "cpu": [
                 "arm64"
             ],
@@ -582,9 +582,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.38.tgz",
-            "integrity": "sha512-YsmyXLbfez4OOwfP7h/2PrwjqhYlFftHpu210RIhxbVnGkKSFIQsdZUfEC0qa+xqiW03B/vPI4AIEw1NUL8MOg==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.39.tgz",
+            "integrity": "sha512-3d9iDDZGqrV6Fhmg5GVKv2uen7BftwIhSCVSfYpxoNGakg+sIs4v0d2a5yN1g6w1uJGuoEmfo7IHPIVcU/or4w==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.38.tgz",
-            "integrity": "sha512-RvDotmljiWgXUiJMoSc2a6vzTvHrmJwsuJkURs+VOi1eO74jnzkIjCZ/T/SoGtOg10ybfHjE10dXFFdjXDjCvw==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.39.tgz",
+            "integrity": "sha512-7IYaWS4e2JYI2RYdrHGsydmzpKiF4hx5+sa1wrbyAI7CKA6euVo1rutMS0Np2v/EzGE+2lwBQXtXcO3q2pI41A==",
             "cpu": [
                 "x64"
             ],
@@ -606,9 +606,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.38.tgz",
-            "integrity": "sha512-bT0wmyfvLMzS7+OVDSdvZOCaKvlXTf6FGIVNJYuulSEjx8z0CwxqSzA8b20r1UgXC5wqVPAADlYG95vRevQaqQ==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.39.tgz",
+            "integrity": "sha512-sQHFOc3oQVXSHuSrdRMJbOfiKIWOMUA/xQrF7NbVzu/TV9RM35b7gXo8xHnwO2Vw/IpCn12TWmnBMCJWEPGJ+w==",
             "cpu": [
                 "x64"
             ],
@@ -618,9 +618,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.38.tgz",
-            "integrity": "sha512-dSWDpO6bAnN73ubandTx7U2lDGwbTmzhPaZ7UNmU8L4gb6j3DhyLTM2dbRsFdBHd8Po3PDPJH1vMy0EcyfRbdA==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.39.tgz",
+            "integrity": "sha512-h6j4y0ZrLcSA4jYGRXYDj782D3TnJkVVEXQ3qtff3+e3fJZzBNJhyn4/S39BYfOZHNFkQ5Q0URSdTWHxpzYYtg==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +630,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.38.tgz",
-            "integrity": "sha512-eUCu+XqAB6wOwYvsEUVJb6wWr8FPu//hpYBnQSc760/BOWGJ/d/7h5mUs1NEFYfYr7OIoD+QWfKLrowNwYN0Bg==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.39.tgz",
+            "integrity": "sha512-SjEKee4g0SJn/pUiIDkhUP5ExAeqlhsm4NT27ad0im0Lrpug0KcN4CxxB2xlnVdVEwpAGOfwVgKDXGL6zKIKBA==",
             "cpu": [
                 "arm64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.38.tgz",
-            "integrity": "sha512-pZlfHisR8e7n8lAhaJRCu6P70KcUiJe9B0P4vpRbM76Tz7UX+eau1Ds1UE6w5Z06ddCySaoJS9CgO4kyM8p4HQ==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.39.tgz",
+            "integrity": "sha512-U3oXHfM7rJs+XBhdSTbg5R9Yhec4m1vXBqMo4q3N50V42eUXO0RQb6m7a4nOCcxupUjrOojIxIXTyNTPoVEr0A==",
             "cpu": [
                 "x64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.38.tgz",
-            "integrity": "sha512-qdvkPY0w8mi96CDat3SXCpQKwLSUZlKzMyeRql00jRnLWzKYUuPYfuz6PLWpPBpNm1IzzffepdIR+K2HvOA9pQ==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.39.tgz",
+            "integrity": "sha512-3XBqVWfj1lTk7DnAHRZGrbD4VNr4OMslog9/8zcfe2zMACElZAbQsT0L26H6XcD1B/gC3BMt2W+ya/qBxP9b/g==",
             "cpu": [
                 "x64"
             ],
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.0.1-rc.8",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.8.tgz",
+            "version": "1.0.1-rc.9",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.9.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -825,27 +825,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.38",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.38.tgz",
-            "integrity": "sha512-o0M2rWFSL3heL+eiwZjpkBA5huBOJBkjIIXzny7FHORsC6sXZM93zPpwHQdUlsx6ogYKXv0f6cYU3kNb8o7wPA==",
+            "version": "1.4.39",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.39.tgz",
+            "integrity": "sha512-wpS0ROwGMjvabreT9ML69zAcDaEi++vt1btcXMLmQMFt1qLGUt1pZS8mn2KYjJaNbdFi/o4rNeZSFDAVy4i8Yw==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.38",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.38",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.38",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.38",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.38",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.38",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.38"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.39",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.39",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.39",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.39",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.39",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.39",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.39"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.8",
+    "version": "1.0.1-rc.9",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -41,7 +41,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.38",
+        "@vrsen/agentswarm": "1.4.39",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
@@ -52,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.8",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.8"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.9",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.9"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.8"
+version = "1.0.1-rc.9"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"
 dependencies = [
-    "agency-swarm[fastapi,jupyter,litellm]>=1.10.0",
+    "agency-swarm[fastapi,jupyter,litellm]>=1.10.1",
     "questionary>=2.0.0",
     "python-dotenv",
     "rich",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agency-swarm[fastapi,jupyter,litellm]>=1.10.0
+agency-swarm[fastapi,jupyter,litellm]>=1.10.1
 questionary>=2.0.0
 fastapi
 uvicorn


### PR DESCRIPTION
## Summary
- Bump OpenSwarm package metadata to `1.0.1-rc.9`.
- Update `@vrsen/agentswarm` to `1.4.39`.
- Set `AGENTSWARM_CLI_VERSION` to `1.4.39` in the Build TUI workflow.
- Raise the Python Agency Swarm minimum to `>=1.10.1`.

## Checks
- Release-input Node check
- `node scripts/smoke-openswarm-launcher.js`
- `uv run --with python-dotenv --with rich --with questionary python scripts/smoke-bootstrap-onboard.py`
- `npm pack --dry-run --json`
- `git diff --check`
- Codex review clean
