### PR TITLE
Update add-on key guidance to use /addons

### DIFF
--- a/shared_tools/model_availability.py
+++ b/shared_tools/model_availability.py
@@ -54,7 +54,7 @@ def image_model_availability_message(tool=None, *, failed_requirement: str | Non
             f"- gpt-image-1.5: {_configured(direct_openai_available(tool))} (requires OpenAI API key auth; not Codex browser auth)",
             f"- background removal / Pixelcut: {_configured(fal_available())} (requires FAL_KEY add-on)",
             "",
-            "If the requested model is unavailable, switch to an available model above or ask the user to run /auth and add the missing add-on key.",
+            "If the requested model is unavailable, switch to an available model above or ask the user to run /addons and add the missing add-on key.",
         ]
     )
     return "\n".join(lines)
@@ -74,7 +74,7 @@ def video_model_availability_message(tool=None, *, failed_requirement: str | Non
             f"- sora-2: {_configured(direct_openai_available(tool))} (requires OpenAI API key auth; not Codex browser auth)",
             f"- sora-2-pro: {_configured(direct_openai_available(tool))} (requires OpenAI API key auth; not Codex browser auth)",
             "",
-            "If the requested model is unavailable, switch to an available model above or ask the user to run /auth and add the missing add-on key.",
+            "If the requested model is unavailable, switch to an available model above or ask the user to run /addons and add the missing add-on key.",
         ]
     )
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Replaces stale `/auth` guidance with `/addons` for missing image and video add-on keys.
- Keeps model availability messaging aligned with the add-on key workflow.

## Checks
- `python3 -m py_compile shared_tools/model_availability.py`
- Searched `shared_tools`, `image_generation_agent`, `video_generation_agent`, `slides_agent`, and `orchestrator` for stale `/auth` add-on guidance.