### PR TITLE
fix: gate hosted tools by provider route

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,9 @@
 """Shared model configuration helpers — read by all agents at startup."""
+from collections.abc import Callable
 import os
+from typing import TypeVar
+
+Tool = TypeVar("Tool")
 
 
 def get_default_model(fallback: str = "gpt-5.2"):
@@ -16,6 +20,13 @@ def is_openai_provider() -> bool:
     'litellm/gemini/gemini-3-flash') is treated as a LiteLLM-routed model.
     """
     return "/" not in os.getenv("DEFAULT_MODEL", "")
+
+
+def openai_hosted_tools(*factories: Callable[[], Tool]) -> list[Tool]:
+    """Instantiate OpenAI hosted tools only for OpenAI-routed agents."""
+    if not is_openai_provider():
+        return []
+    return [factory() for factory in factories]
 
 
 def _resolve(model: str):

--- a/data_analyst_agent/data_analyst_agent.py
+++ b/data_analyst_agent/data_analyst_agent.py
@@ -9,7 +9,7 @@ from agency_swarm.tools import (
 )
 from shared_tools import CopyFile, ExecuteTool, FindTools, ManageConnections, SearchTools
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, openai_hosted_tools
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 instructions_path = os.path.join(current_dir, "instructions.md")
@@ -22,7 +22,7 @@ def create_data_analyst() -> Agent:
         tools_folder=os.path.join(current_dir, "tools"),
         model=get_default_model(),
         tools=[
-            WebSearchTool(),
+            *openai_hosted_tools(WebSearchTool),
             PersistentShellTool,
             IPythonInterpreter,
             LoadFileAttachment,

--- a/deep_research/deep_research.py
+++ b/deep_research/deep_research.py
@@ -3,7 +3,7 @@ from agency_swarm.tools import WebSearchTool, IPythonInterpreter
 from openai.types.shared import Reasoning
 from virtual_assistant.tools.ScholarSearch import ScholarSearch
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, openai_hosted_tools
 
 
 def create_deep_research() -> Agent:
@@ -12,7 +12,7 @@ def create_deep_research() -> Agent:
         description="Comprehensive deep research agent that conducts thorough research on any topic.",
         instructions="./instructions.md",
         files_folder="./files",
-        tools=[WebSearchTool(), ScholarSearch, IPythonInterpreter],
+        tools=[*openai_hosted_tools(WebSearchTool), ScholarSearch, IPythonInterpreter],
         model=get_default_model(),
         model_settings=ModelSettings(
             reasoning=Reasoning(effort="high", summary="auto") if is_openai_provider() else None,

--- a/docs_agent/docs_agent.py
+++ b/docs_agent/docs_agent.py
@@ -6,7 +6,7 @@ from agency_swarm.tools import IPythonInterpreter, WebSearchTool
 from openai.types.shared import Reasoning
 from shared_tools import CopyFile
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, openai_hosted_tools
 
 _INSTRUCTIONS_PATH = Path(__file__).parent / "instructions.md"
 
@@ -43,7 +43,7 @@ def create_docs_agent() -> Agent:
             reasoning=Reasoning(effort="medium", summary="auto") if is_openai_provider() else None,
             response_include=["web_search_call.action.sources"] if is_openai_provider() else None,
         ),
-        tools=[WebSearchTool(), IPythonInterpreter, CopyFile],
+        tools=[*openai_hosted_tools(WebSearchTool), IPythonInterpreter, CopyFile],
         conversation_starters=[
             "Draft Week 34 client status report with a table and export as PDF.",
             "Create a one-page AI chatbot proposal and export as DOCX.",

--- a/scripts/smoke-hosted-tools-gating.py
+++ b/scripts/smoke-hosted-tools-gating.py
@@ -1,0 +1,95 @@
+"""Smoke test that OpenAI hosted tools follow the selected model route."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+import importlib
+import io
+import os
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agency_swarm.tools import WebSearchTool  # noqa: E402
+
+AGENTS: tuple[tuple[str, str], ...] = (
+    ("deep_research.deep_research", "create_deep_research"),
+    ("virtual_assistant.virtual_assistant", "create_virtual_assistant"),
+    ("docs_agent.docs_agent", "create_docs_agent"),
+    ("slides_agent.slides_agent", "create_slides_agent"),
+    ("data_analyst_agent.data_analyst_agent", "create_data_analyst"),
+)
+
+
+@contextmanager
+def _default_model(model: str) -> Iterator[None]:
+    previous = os.environ.get("DEFAULT_MODEL")
+    os.environ["DEFAULT_MODEL"] = model
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("DEFAULT_MODEL", None)
+        else:
+            os.environ["DEFAULT_MODEL"] = previous
+
+
+def _assert_helper_is_lazy() -> None:
+    import config
+
+    called: list[object] = []
+
+    def factory() -> object:
+        called.append(object())
+        return object()
+
+    with _default_model("litellm/ollama_chat/gemma4:e4b"):
+        tools = config.openai_hosted_tools(factory)
+    if tools or called:
+        raise AssertionError("Hosted tool factory ran for a non-OpenAI route")
+
+    with _default_model("gpt-5.2"):
+        tools = config.openai_hosted_tools(factory)
+    if len(tools) != 1 or len(called) != 1:
+        raise AssertionError("Hosted tool factory did not run once for OpenAI")
+
+
+def _assert_hosted_tool_count(model: str, expected: int) -> None:
+    with _default_model(model):
+        for module_name, factory_name in AGENTS:
+            agent = _create_agent(module_name, factory_name)
+            actual = sum(isinstance(tool, WebSearchTool) for tool in agent.tools)
+            if actual != expected:
+                raise AssertionError(
+                    f"{module_name} expected {expected} WebSearchTool instances, got {actual}"
+                )
+
+
+def _create_agent(module_name: str, factory_name: str) -> object:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            module = importlib.import_module(module_name)
+            return getattr(module, factory_name)()
+    except Exception:
+        sys.stdout.write(stdout.getvalue())
+        sys.stderr.write(stderr.getvalue())
+        raise
+
+
+def main() -> None:
+    _assert_helper_is_lazy()
+    _assert_hosted_tool_count("gpt-5.2", 1)
+    _assert_hosted_tool_count("litellm/ollama_chat/gemma4:e4b", 0)
+    _assert_hosted_tool_count("litellm/gemini/gemini-3-flash", 0)
+    _assert_hosted_tool_count("openrouter/openai/gpt-4o-mini", 0)
+    print("Hosted tool gating smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/slides_agent/slides_agent.py
+++ b/slides_agent/slides_agent.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from virtual_assistant.tools.ReadFile import ReadFile
 from shared_tools.CopyFile import CopyFile
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, openai_hosted_tools
 
 # Import slide tools
 from .tools import (
@@ -86,7 +86,7 @@ def create_slides_agent() -> Agent:
             LoadFileAttachment,
             CopyFile,
             ReadFile,
-            WebSearchTool(search_context_size="high"),
+            *openai_hosted_tools(lambda: WebSearchTool(search_context_size="high")),
         ],
         model=get_default_model(),
         model_settings=ModelSettings(

--- a/virtual_assistant/virtual_assistant.py
+++ b/virtual_assistant/virtual_assistant.py
@@ -6,7 +6,7 @@ from agency_swarm.tools import (
 )
 from openai.types.shared import Reasoning
 
-from config import get_default_model, is_openai_provider
+from config import get_default_model, is_openai_provider, openai_hosted_tools
 from run_utils import _load_openswarm_dotenv
 from shared_tools import CopyFile, ExecuteTool, FindTools, ManageConnections, SearchTools
 
@@ -29,7 +29,7 @@ def create_virtual_assistant() -> Agent:
             response_include=["web_search_call.action.sources"] if is_openai_provider() else None,
         ),
         tools=[
-            WebSearchTool(),
+            *openai_hosted_tools(WebSearchTool),
             PersistentShellTool,
             IPythonInterpreter,
             CopyFile,


### PR DESCRIPTION
## Summary

- keep OpenAI hosted WebSearchTool only on direct OpenAI model routes
- omit hosted tools for provider-routed models such as LiteLLM/Ollama/OpenRouter
- add a smoke check that covers OpenAI and non-OpenAI routes

## QA

- `python scripts/smoke-hosted-tools-gating.py`
- `python -m py_compile config.py data_analyst_agent/data_analyst_agent.py deep_research/deep_research.py docs_agent/docs_agent.py slides_agent/slides_agent.py virtual_assistant/virtual_assistant.py scripts/smoke-hosted-tools-gating.py`
- `git diff --check`
