### PR TITLE
feat: add marketplace fork attribution metadata

### DIFF
--- a/.github/workflows/live-run-mode-smoke.yml
+++ b/.github/workflows/live-run-mode-smoke.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/live-run-mode-smoke.yml'
       - 'bin/openswarm'
       - 'openswarm.config.mjs'
+      - 'openswarm.marketplace.json'
       - 'package-lock.json'
       - 'package.json'
       - 'pyproject.toml'

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/test-mac.yml'
       - 'bin/openswarm'
       - 'openswarm.config.mjs'
+      - 'openswarm.marketplace.json'
       - 'package.json'
       - 'package-lock.json'
       - 'run_utils.py'

--- a/bin/openswarm
+++ b/bin/openswarm
@@ -180,14 +180,18 @@ if (isVersionRequest(process.argv.slice(2))) {
 
 async function main() {
   const config = await import(pathToFileURL(path.join(packageDir, 'openswarm.config.mjs')).href)
+  const productEnv = config.getProductEnv({ env: process.env })
   const env = {
     ...process.env,
-    ...config.getProductEnv(),
+    ...productEnv,
     ...telemetryEnv(process.env),
     AGENTSWARM_LAUNCHER: process.env.AGENTSWARM_LAUNCHER || '1',
     AGENTSWARM_BIN_PATH: openswarmBinary,
     PYTHONUTF8: process.env.PYTHONUTF8 || '1',
     PYTHONIOENCODING: process.env.PYTHONIOENCODING || 'utf-8',
+  }
+  if (!('AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID' in productEnv)) {
+    delete env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID
   }
 
   const result = childProcess.spawnSync(process.execPath, [agentswarmBin, ...process.argv.slice(2)], {

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -9,12 +9,8 @@ const defaultMarketplace = {
   parentSwarmId: undefined,
   swarmOrigin: "original",
 }
-const githubRepoPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/
-const marketplaceEnv = {
-  swarmId: "OPENSWARM_MARKETPLACE_SWARM_ID",
-  parentSwarmId: "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID",
-  swarmOrigin: "OPENSWARM_MARKETPLACE_SWARM_ORIGIN",
-}
+const githubOwnerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+const githubRepositoryNamePattern = /^[A-Za-z0-9._-]{1,100}$/
 
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -31,7 +27,12 @@ function readString(value, key, { required = true } = {}) {
 function readGitHubRepo(value, key, opts) {
   const repo = readString(value, key, opts)
   if (repo === undefined) return undefined
-  if (!githubRepoPattern.test(repo)) {
+  const parts = repo.split("/")
+  if (parts.length !== 2) {
+    throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
+  }
+  const [owner, name] = parts
+  if (!githubOwnerPattern.test(owner) || owner.includes("--") || !githubRepositoryNamePattern.test(name)) {
     throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
   }
   return repo
@@ -59,26 +60,6 @@ function readMarketplaceFileMetadata() {
   }
   return {
     swarmId: readGitHubRepo(parsed.swarmId, "swarmId"),
-    parentSwarmId,
-    swarmOrigin,
-  }
-}
-
-function readMarketplaceEnv(env = process.env) {
-  const hasEnv = Object.values(marketplaceEnv).some((key) => typeof env[key] === "string" && env[key].trim() !== "")
-  if (!hasEnv) return undefined
-  const swarmOrigin = readString(env[marketplaceEnv.swarmOrigin], marketplaceEnv.swarmOrigin)
-  if (!["original", "fork", "unknown"].includes(swarmOrigin)) {
-    throw new Error("OpenSwarm marketplace metadata OPENSWARM_MARKETPLACE_SWARM_ORIGIN must be original, fork, or unknown")
-  }
-  const parentSwarmId = readGitHubRepo(env[marketplaceEnv.parentSwarmId], marketplaceEnv.parentSwarmId, {
-    required: false,
-  })
-  if (swarmOrigin === "fork" && parentSwarmId === undefined) {
-    throw new Error("OpenSwarm marketplace metadata OPENSWARM_MARKETPLACE_PARENT_SWARM_ID is required for fork swarms")
-  }
-  return {
-    swarmId: readGitHubRepo(env[marketplaceEnv.swarmId], marketplaceEnv.swarmId),
     parentSwarmId,
     swarmOrigin,
   }
@@ -149,7 +130,7 @@ export function resolveStateRoot(env = process.env, platform = process.platform,
 }
 
 export function getProductEnv(opts = {}) {
-  const activeMarketplace = readMarketplaceEnv(opts.env) ?? {
+  const activeMarketplace = {
     swarmId: product.marketplaceSwarmId,
     parentSwarmId: product.marketplaceParentSwarmId,
     swarmOrigin: product.marketplaceSwarmOrigin,

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs"
 import path from "node:path"
 
 export const productVersion = JSON.parse(fs.readFileSync(new URL("./package.json", import.meta.url), "utf8")).version
-const marketplacePath = new URL("./openswarm.marketplace.json", import.meta.url)
+const packageMarketplacePath = new URL("./openswarm.marketplace.json", import.meta.url)
 const defaultMarketplace = {
   swarmId: "VRSEN/OpenSwarm",
   parentSwarmId: undefined,
@@ -41,11 +41,21 @@ function readGitHubRepo(value, key, opts) {
   return repo
 }
 
-function readMarketplaceFileMetadata() {
-  if (!fs.existsSync(marketplacePath)) return defaultMarketplace
+function marketplacePath(cwd) {
+  if (cwd) {
+    const projectPath = path.resolve(cwd, "openswarm.marketplace.json")
+    if (fs.existsSync(projectPath)) return projectPath
+  }
+  if (fs.existsSync(packageMarketplacePath)) return packageMarketplacePath
+  return undefined
+}
+
+function readMarketplaceFileMetadata(cwd) {
+  const source = marketplacePath(cwd)
+  if (!source) return defaultMarketplace
   let parsed
   try {
-    parsed = JSON.parse(fs.readFileSync(marketplacePath, "utf8"))
+    parsed = JSON.parse(fs.readFileSync(source, "utf8"))
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`OpenSwarm marketplace metadata failed to load: ${message}`)
@@ -133,10 +143,11 @@ export function resolveStateRoot(env = process.env, platform = process.platform,
 }
 
 export function getProductEnv(opts = {}) {
+  const marketplace = readMarketplaceFileMetadata(opts.cwd ?? process.cwd())
   const activeMarketplace = {
-    swarmId: product.marketplaceSwarmId,
-    parentSwarmId: product.marketplaceParentSwarmId,
-    swarmOrigin: product.marketplaceSwarmOrigin,
+    swarmId: marketplace.swarmId,
+    parentSwarmId: marketplace.parentSwarmId,
+    swarmOrigin: marketplace.swarmOrigin,
   }
   const env = {
     AGENTSWARM_PRODUCT_DISPLAY_NAME: product.displayName,

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -32,6 +32,9 @@ function readGitHubRepo(value, key, opts) {
     throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
   }
   const [owner, name] = parts
+  if (name.endsWith(".git")) {
+    throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
+  }
   if (!githubOwnerPattern.test(owner) || owner.includes("--") || !githubRepositoryNamePattern.test(name)) {
     throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
   }

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -32,7 +32,7 @@ function readGitHubRepo(value, key, opts) {
     throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
   }
   const [owner, name] = parts
-  if (name.endsWith(".git")) {
+  if (name.toLowerCase().endsWith(".git")) {
     throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
   }
   if (!githubOwnerPattern.test(owner) || owner.includes("--") || !githubRepositoryNamePattern.test(name)) {

--- a/openswarm.config.mjs
+++ b/openswarm.config.mjs
@@ -3,6 +3,88 @@ import fs from "node:fs"
 import path from "node:path"
 
 export const productVersion = JSON.parse(fs.readFileSync(new URL("./package.json", import.meta.url), "utf8")).version
+const marketplacePath = new URL("./openswarm.marketplace.json", import.meta.url)
+const defaultMarketplace = {
+  swarmId: "VRSEN/OpenSwarm",
+  parentSwarmId: undefined,
+  swarmOrigin: "original",
+}
+const githubRepoPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]{1,100}$/
+const marketplaceEnv = {
+  swarmId: "OPENSWARM_MARKETPLACE_SWARM_ID",
+  parentSwarmId: "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID",
+  swarmOrigin: "OPENSWARM_MARKETPLACE_SWARM_ORIGIN",
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readString(value, key, { required = true } = {}) {
+  if ((value === undefined || value === "") && !required) return undefined
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`OpenSwarm marketplace metadata ${key} must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function readGitHubRepo(value, key, opts) {
+  const repo = readString(value, key, opts)
+  if (repo === undefined) return undefined
+  if (!githubRepoPattern.test(repo)) {
+    throw new Error(`OpenSwarm marketplace metadata ${key} must be a GitHub owner/repo`)
+  }
+  return repo
+}
+
+function readMarketplaceFileMetadata() {
+  if (!fs.existsSync(marketplacePath)) return defaultMarketplace
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(marketplacePath, "utf8"))
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`OpenSwarm marketplace metadata failed to load: ${message}`)
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("OpenSwarm marketplace metadata must be a JSON object")
+  }
+  const swarmOrigin = readString(parsed.swarmOrigin, "swarmOrigin")
+  if (!["original", "fork", "unknown"].includes(swarmOrigin)) {
+    throw new Error("OpenSwarm marketplace metadata swarmOrigin must be original, fork, or unknown")
+  }
+  const parentSwarmId = readGitHubRepo(parsed.parentSwarmId, "parentSwarmId", { required: false })
+  if (swarmOrigin === "fork" && parentSwarmId === undefined) {
+    throw new Error("OpenSwarm marketplace metadata parentSwarmId is required for fork swarms")
+  }
+  return {
+    swarmId: readGitHubRepo(parsed.swarmId, "swarmId"),
+    parentSwarmId,
+    swarmOrigin,
+  }
+}
+
+function readMarketplaceEnv(env = process.env) {
+  const hasEnv = Object.values(marketplaceEnv).some((key) => typeof env[key] === "string" && env[key].trim() !== "")
+  if (!hasEnv) return undefined
+  const swarmOrigin = readString(env[marketplaceEnv.swarmOrigin], marketplaceEnv.swarmOrigin)
+  if (!["original", "fork", "unknown"].includes(swarmOrigin)) {
+    throw new Error("OpenSwarm marketplace metadata OPENSWARM_MARKETPLACE_SWARM_ORIGIN must be original, fork, or unknown")
+  }
+  const parentSwarmId = readGitHubRepo(env[marketplaceEnv.parentSwarmId], marketplaceEnv.parentSwarmId, {
+    required: false,
+  })
+  if (swarmOrigin === "fork" && parentSwarmId === undefined) {
+    throw new Error("OpenSwarm marketplace metadata OPENSWARM_MARKETPLACE_PARENT_SWARM_ID is required for fork swarms")
+  }
+  return {
+    swarmId: readGitHubRepo(env[marketplaceEnv.swarmId], marketplaceEnv.swarmId),
+    parentSwarmId,
+    swarmOrigin,
+  }
+}
+
+const marketplace = readMarketplaceFileMetadata()
 
 // Downstream projects can edit this file to rebrand the launcher and TUI build.
 export const product = {
@@ -17,9 +99,9 @@ export const product = {
   starterRepo: "VRSEN/OpenSwarm",
   starterFolder: "openswarm",
   entryFiles: "swarm.py,agency.py",
-  marketplaceSwarmId: "openswarm",
-  marketplaceParentSwarmId: undefined,
-  marketplaceSwarmOrigin: "original",
+  marketplaceSwarmId: marketplace.swarmId,
+  marketplaceParentSwarmId: marketplace.parentSwarmId,
+  marketplaceSwarmOrigin: marketplace.swarmOrigin,
 }
 
 export const productTuiLogoLeft = [
@@ -67,6 +149,11 @@ export function resolveStateRoot(env = process.env, platform = process.platform,
 }
 
 export function getProductEnv(opts = {}) {
+  const activeMarketplace = readMarketplaceEnv(opts.env) ?? {
+    swarmId: product.marketplaceSwarmId,
+    parentSwarmId: product.marketplaceParentSwarmId,
+    swarmOrigin: product.marketplaceSwarmOrigin,
+  }
   const env = {
     AGENTSWARM_PRODUCT_DISPLAY_NAME: product.displayName,
     AGENTSWARM_PRODUCT_COMMAND: product.command,
@@ -88,11 +175,11 @@ export function getProductEnv(opts = {}) {
     AGENTSWARM_PRODUCT_ADDONS: JSON.stringify(productAddons),
     AGENTSWARM_PRODUCT_STATE_ROOT: opts.stateRoot ?? resolveStateRoot(opts.env),
     AGENTSWARM_PRODUCT_VERSION: productVersion,
-    AGENTSWARM_MARKETPLACE_SWARM_ID: product.marketplaceSwarmId,
-    AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: product.marketplaceSwarmOrigin,
+    AGENTSWARM_MARKETPLACE_SWARM_ID: activeMarketplace.swarmId,
+    AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: activeMarketplace.swarmOrigin,
   }
-  if (product.marketplaceParentSwarmId) {
-    env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID = product.marketplaceParentSwarmId
+  if (activeMarketplace.parentSwarmId) {
+    env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID = activeMarketplace.parentSwarmId
   }
   return env
 }

--- a/openswarm.marketplace.json
+++ b/openswarm.marketplace.json
@@ -1,0 +1,4 @@
+{
+  "swarmId": "VRSEN/OpenSwarm",
+  "swarmOrigin": "original"
+}

--- a/openswarm.product-env.json
+++ b/openswarm.product-env.json
@@ -17,6 +17,6 @@
   "AGENTSWARM_PRODUCT_PYTHON_ENVIRONMENT": "standalone",
   "AGENTSWARM_PRODUCT_ENABLE_ADDONS": "true",
   "AGENTSWARM_PRODUCT_ADDONS": "[{\"id\":\"search\",\"title\":\"Web Search\",\"keys\":[\"SEARCH_API_KEY\"]},{\"id\":\"anthropic\",\"title\":\"Anthropic Claude\",\"keys\":[\"ANTHROPIC_API_KEY\"],\"excludeProviders\":[\"anthropic\"]},{\"id\":\"composio\",\"title\":\"Composio\",\"keys\":[\"COMPOSIO_API_KEY\",\"COMPOSIO_USER_ID\"]},{\"id\":\"google\",\"title\":\"Google Gemini\",\"keys\":[\"GOOGLE_API_KEY\"],\"excludeProviders\":[\"google\"]},{\"id\":\"fal\",\"title\":\"Fal.ai\",\"keys\":[\"FAL_KEY\"]},{\"id\":\"pexels\",\"title\":\"Pexels\",\"keys\":[\"PEXELS_API_KEY\"]},{\"id\":\"pixabay\",\"title\":\"Pixabay\",\"keys\":[\"PIXABAY_API_KEY\"]},{\"id\":\"unsplash\",\"title\":\"Unsplash\",\"keys\":[\"UNSPLASH_ACCESS_KEY\"]}]",
-  "AGENTSWARM_MARKETPLACE_SWARM_ID": "openswarm",
+  "AGENTSWARM_MARKETPLACE_SWARM_ID": "VRSEN/OpenSwarm",
   "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN": "original"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "files": [
         "bin/",
         "openswarm.config.mjs",
+        "openswarm.marketplace.json",
         "openswarm.product-env.json",
         "run_utils.py",
         "swarm.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,5 +70,5 @@ exclude = ["agentswarm-cli*", "venv*", ".venv*", ".agency_swarm*", "node_modules
 "*" = ["*.md", "*.json", "*.mjs", "agency-*"]
 
 [tool.setuptools.data-files]
-"." = ["openswarm.config.mjs", "openswarm.product-env.json", "package.json"]
+"." = ["openswarm.config.mjs", "openswarm.marketplace.json", "openswarm.product-env.json", "package.json"]
 "patches" = ["patches/dom-to-pptx+1.1.5.patch"]

--- a/run_utils.py
+++ b/run_utils.py
@@ -159,7 +159,7 @@ def _marketplace_repo(values: dict[str, object], key: str, *, required: bool = T
     if len(parts) != 2:
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     owner, name = parts
-    if name.endswith(".git"):
+    if name.lower().endswith(".git"):
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     if not _GITHUB_OWNER_PATTERN.fullmatch(owner) or "--" in owner or not _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(name):
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")

--- a/run_utils.py
+++ b/run_utils.py
@@ -8,11 +8,8 @@ import shutil
 import platform as platform_module
 from pathlib import Path
 
-_MARKETPLACE_ENV_KEYS = {
-    "swarmId": "OPENSWARM_MARKETPLACE_SWARM_ID",
-    "parentSwarmId": "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID",
-    "swarmOrigin": "OPENSWARM_MARKETPLACE_SWARM_ORIGIN",
-}
+_GITHUB_OWNER_PATTERN = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+_GITHUB_REPOSITORY_NAME_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,100}")
 
 
 def _openswarm_state_root() -> Path:
@@ -97,7 +94,7 @@ def _product_env_from_json(fallback: Path, package: Path) -> dict[str, str]:
     if not isinstance(package_values, dict) or not package_values.get("version"):
         raise RuntimeError("OpenSwarm package metadata is invalid. Reinstall OpenSwarm through npm or npx.")
     env = {key: str(value) for key, value in values.items()}
-    marketplace_env = _marketplace_env_from_process() or _marketplace_env_from_json(fallback.parent)
+    marketplace_env = _marketplace_env_from_json(fallback.parent)
     if marketplace_env:
         for key in (
             "AGENTSWARM_MARKETPLACE_SWARM_ID",
@@ -123,15 +120,6 @@ def _marketplace_env_from_json(root: Path) -> dict[str, str]:
         raise RuntimeError("OpenSwarm marketplace metadata must be a JSON object.")
 
     return _marketplace_env_from_values(values)
-
-
-def _marketplace_env_from_process() -> dict[str, str]:
-    if not any(os.getenv(key, "").strip() for key in _MARKETPLACE_ENV_KEYS.values()):
-        return {}
-    return _marketplace_env_from_values({
-        key: os.getenv(env_key)
-        for key, env_key in _MARKETPLACE_ENV_KEYS.items()
-    })
 
 
 def _marketplace_env_from_values(values: dict[str, object]) -> dict[str, str]:
@@ -167,7 +155,11 @@ def _marketplace_repo(values: dict[str, object], key: str, *, required: bool = T
     repo = _metadata_string(values, key, required=required)
     if repo is None:
         return None
-    if not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]{1,100}", repo):
+    parts = repo.split("/")
+    if len(parts) != 2:
+        raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
+    owner, name = parts
+    if not _GITHUB_OWNER_PATTERN.fullmatch(owner) or "--" in owner or not _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(name):
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     return repo
 

--- a/run_utils.py
+++ b/run_utils.py
@@ -1,11 +1,18 @@
 import json
 import os
+import re
 import sys
 import site
 import subprocess
 import shutil
 import platform as platform_module
 from pathlib import Path
+
+_MARKETPLACE_ENV_KEYS = {
+    "swarmId": "OPENSWARM_MARKETPLACE_SWARM_ID",
+    "parentSwarmId": "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID",
+    "swarmOrigin": "OPENSWARM_MARKETPLACE_SWARM_ORIGIN",
+}
 
 
 def _openswarm_state_root() -> Path:
@@ -90,9 +97,79 @@ def _product_env_from_json(fallback: Path, package: Path) -> dict[str, str]:
     if not isinstance(package_values, dict) or not package_values.get("version"):
         raise RuntimeError("OpenSwarm package metadata is invalid. Reinstall OpenSwarm through npm or npx.")
     env = {key: str(value) for key, value in values.items()}
+    marketplace_env = _marketplace_env_from_process() or _marketplace_env_from_json(fallback.parent)
+    if marketplace_env:
+        for key in (
+            "AGENTSWARM_MARKETPLACE_SWARM_ID",
+            "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID",
+            "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN",
+        ):
+            env.pop(key, None)
+        env.update(marketplace_env)
     env["AGENTSWARM_PRODUCT_STATE_ROOT"] = str(_openswarm_state_root())
     env["AGENTSWARM_PRODUCT_VERSION"] = str(package_values["version"])
     return env
+
+
+def _marketplace_env_from_json(root: Path) -> dict[str, str]:
+    path = root / "openswarm.marketplace.json"
+    if not path.exists():
+        return {}
+    try:
+        values = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"OpenSwarm marketplace metadata failed to load: {exc}") from exc
+    if not isinstance(values, dict):
+        raise RuntimeError("OpenSwarm marketplace metadata must be a JSON object.")
+
+    return _marketplace_env_from_values(values)
+
+
+def _marketplace_env_from_process() -> dict[str, str]:
+    if not any(os.getenv(key, "").strip() for key in _MARKETPLACE_ENV_KEYS.values()):
+        return {}
+    return _marketplace_env_from_values({
+        key: os.getenv(env_key)
+        for key, env_key in _MARKETPLACE_ENV_KEYS.items()
+    })
+
+
+def _marketplace_env_from_values(values: dict[str, object]) -> dict[str, str]:
+    swarm_id = _marketplace_repo(values, "swarmId")
+    parent_swarm_id = _marketplace_repo(values, "parentSwarmId", required=False)
+    swarm_origin = _metadata_string(values, "swarmOrigin")
+    if swarm_origin not in {"original", "fork", "unknown"}:
+        raise RuntimeError("OpenSwarm marketplace metadata swarmOrigin must be original, fork, or unknown.")
+    if swarm_origin == "fork" and parent_swarm_id is None:
+        raise RuntimeError("OpenSwarm marketplace metadata parentSwarmId is required for fork swarms.")
+
+    env = {
+        "AGENTSWARM_MARKETPLACE_SWARM_ID": swarm_id,
+        "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN": swarm_origin,
+    }
+    if parent_swarm_id:
+        env["AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID"] = parent_swarm_id
+    else:
+        env.pop("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID", None)
+    return env
+
+
+def _metadata_string(values: dict[str, object], key: str, *, required: bool = True) -> str | None:
+    value = values.get(key)
+    if (value is None or value == "") and not required:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a non-empty string.")
+    return value.strip()
+
+
+def _marketplace_repo(values: dict[str, object], key: str, *, required: bool = True) -> str | None:
+    repo = _metadata_string(values, key, required=required)
+    if repo is None:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?/[A-Za-z0-9._-]{1,100}", repo):
+        raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
+    return repo
 
 
 def _disables_telemetry(value: str | None) -> bool:
@@ -100,11 +177,20 @@ def _disables_telemetry(value: str | None) -> bool:
 
 
 def _configure_product_env() -> None:
-    for key, value in _product_env_from_config().items():
-        if key in {"AGENTSWARM_PRODUCT_STATE_ROOT", "AGENTSWARM_PRODUCT_VERSION"}:
+    product_env = _product_env_from_config()
+    for key, value in product_env.items():
+        if key in {
+            "AGENTSWARM_PRODUCT_STATE_ROOT",
+            "AGENTSWARM_PRODUCT_VERSION",
+            "AGENTSWARM_MARKETPLACE_SWARM_ID",
+            "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID",
+            "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN",
+        }:
             os.environ[key] = value
         else:
             os.environ.setdefault(key, value)
+    if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" not in product_env:
+        os.environ.pop("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID", None)
     if _disables_telemetry(os.environ.get("ENABLE_TELEMETRY")):
         os.environ["OPEN_SWARM_TELEMETRY"] = "0"
         os.environ["AGENTSWARM_TELEMETRY"] = "0"

--- a/run_utils.py
+++ b/run_utils.py
@@ -94,7 +94,7 @@ def _product_env_from_json(fallback: Path, package: Path) -> dict[str, str]:
     if not isinstance(package_values, dict) or not package_values.get("version"):
         raise RuntimeError("OpenSwarm package metadata is invalid. Reinstall OpenSwarm through npm or npx.")
     env = {key: str(value) for key, value in values.items()}
-    marketplace_env = _marketplace_env_from_json(fallback.parent)
+    marketplace_env = _marketplace_env_from_json(fallback.parent, Path.cwd())
     if marketplace_env:
         for key in (
             "AGENTSWARM_MARKETPLACE_SWARM_ID",
@@ -108,9 +108,13 @@ def _product_env_from_json(fallback: Path, package: Path) -> dict[str, str]:
     return env
 
 
-def _marketplace_env_from_json(root: Path) -> dict[str, str]:
-    path = root / "openswarm.marketplace.json"
-    if not path.exists():
+def _marketplace_env_from_json(root: Path, project: Path | None = None) -> dict[str, str]:
+    paths = []
+    if project:
+        paths.append(project / "openswarm.marketplace.json")
+    paths.append(root / "openswarm.marketplace.json")
+    path = next((item for item in dict.fromkeys(paths) if item.exists()), None)
+    if path is None:
         return {}
     try:
         values = json.loads(path.read_text(encoding="utf-8"))

--- a/run_utils.py
+++ b/run_utils.py
@@ -159,6 +159,8 @@ def _marketplace_repo(values: dict[str, object], key: str, *, required: bool = T
     if len(parts) != 2:
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     owner, name = parts
+    if name.endswith(".git"):
+        raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     if not _GITHUB_OWNER_PATTERN.fullmatch(owner) or "--" in owner or not _GITHUB_REPOSITORY_NAME_PATTERN.fullmatch(name):
         raise RuntimeError(f"OpenSwarm marketplace metadata {key} must be a GitHub owner/repo.")
     return repo

--- a/scripts/smoke-bootstrap.py
+++ b/scripts/smoke-bootstrap.py
@@ -364,6 +364,33 @@ def smoke_product_state_root_env() -> None:
         if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
             raise RuntimeError("OpenSwarm Python fallback product env did not send marketplace metadata")
 
+        project = base / "project"
+        project.mkdir()
+        (project / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"someone/project-swarm","parentSwarmId":"VRSEN/OpenSwarm","swarmOrigin":"fork"}\n',
+            encoding="utf-8",
+        )
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(project)
+            with (
+                patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+                patch.object(run_utils.sys, "prefix", str(prefix)),
+                patch.object(run_utils.site, "USER_BASE", str(userbase)),
+                patch.object(run_utils.shutil, "which", lambda _name: None),
+                patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+                clean_marketplace_env(),
+            ):
+                values = run_utils._product_env_from_config()
+        finally:
+            os.chdir(old_cwd)
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/project-swarm":
+            raise RuntimeError("OpenSwarm Python fallback did not prefer project marketplace metadata")
+        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback did not use project marketplace parent swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
+            raise RuntimeError("OpenSwarm Python fallback did not use project marketplace origin")
+
         with (
             patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
             patch.object(run_utils.sys, "prefix", str(prefix)),
@@ -502,6 +529,7 @@ def smoke_product_state_root_env() -> None:
 
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -520,6 +548,7 @@ def smoke_product_state_root_env() -> None:
         (early / "openswarm.marketplace.json").write_text('{"swarmId":"","swarmOrigin":"fork"}\n', encoding="utf-8")
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -536,6 +565,7 @@ def smoke_product_state_root_env() -> None:
         (early / "openswarm.marketplace.json").write_text('{"swarmId":"openswarm","swarmOrigin":"fork"}\n', encoding="utf-8")
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -555,6 +585,7 @@ def smoke_product_state_root_env() -> None:
         )
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -574,6 +605,7 @@ def smoke_product_state_root_env() -> None:
         )
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -593,6 +625,7 @@ def smoke_product_state_root_env() -> None:
         )
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -612,6 +645,7 @@ def smoke_product_state_root_env() -> None:
         )
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
@@ -631,6 +665,7 @@ def smoke_product_state_root_env() -> None:
         )
         with (
             patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.Path, "cwd", lambda: base),
             patch.object(run_utils.sys, "prefix", str(later)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),

--- a/scripts/smoke-bootstrap.py
+++ b/scripts/smoke-bootstrap.py
@@ -569,7 +569,7 @@ def smoke_product_state_root_env() -> None:
                 raise RuntimeError("OpenSwarm Python fallback accepted invalid GitHub owner metadata")
 
         (early / "openswarm.marketplace.json").write_text(
-            '{"swarmId":"someone/custom-swarm.git","swarmOrigin":"original"}\n',
+            '{"swarmId":"someone/custom-swarm.GIT","swarmOrigin":"original"}\n',
             encoding="utf-8",
         )
         with (

--- a/scripts/smoke-bootstrap.py
+++ b/scripts/smoke-bootstrap.py
@@ -17,6 +17,30 @@ from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE_ENV_KEYS = (
+    "OPENSWARM_MARKETPLACE_SWARM_ID",
+    "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID",
+    "OPENSWARM_MARKETPLACE_SWARM_ORIGIN",
+    "AGENTSWARM_MARKETPLACE_SWARM_ID",
+    "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID",
+    "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN",
+)
+
+
+@contextmanager
+def clean_marketplace_env(extra: dict[str, str] | None = None) -> Iterator[None]:
+    old = {key: os.environ.get(key) for key in MARKETPLACE_ENV_KEYS}
+    try:
+        for key in MARKETPLACE_ENV_KEYS:
+            os.environ.pop(key, None)
+        if extra:
+            os.environ.update(extra)
+        yield
+    finally:
+        for key in MARKETPLACE_ENV_KEYS:
+            os.environ.pop(key, None)
+            if old[key] is not None:
+                os.environ[key] = old[key]
 
 
 @contextmanager
@@ -49,6 +73,7 @@ def smoke_swarm_import_skips_bootstrap() -> None:
         "run_utils": module(
             "run_utils",
             _bootstrap=lambda: order.append("bootstrap"),
+            _configure_product_env=lambda: order.append("product-env"),
             _openswarm_state_root=lambda: ROOT,
             _preload_agentswarm_bin=lambda: order.append("preload"),
         ),
@@ -87,6 +112,83 @@ def smoke_swarm_import_skips_bootstrap() -> None:
         raise RuntimeError(f"swarm.py ran bootstrap during import: {order}")
     if not order or order[0] != "dotenv":
         raise RuntimeError(f"swarm.py did not configure runtime during import: {order}")
+
+
+def smoke_swarm_main_configures_product_env() -> None:
+    order: list[str] = []
+
+    class Agent:
+        def __gt__(self, other: object) -> tuple[object, object]:
+            return (self, other)
+
+    class Agency:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            order.append("agency")
+
+        def tui(self, **kwargs: object) -> None:
+            order.append("tui")
+
+    patches = module("patches", __path__=[])
+    replacements = {
+        "run_utils": module(
+            "run_utils",
+            _bootstrap=lambda: order.append("bootstrap"),
+            _configure_product_env=lambda: order.append("product-env"),
+            _openswarm_state_root=lambda: ROOT,
+            _preload_agentswarm_bin=lambda: order.append("preload"),
+        ),
+        "dotenv": module("dotenv", load_dotenv=lambda *args, **kwargs: order.append("dotenv")),
+        "agents": module(
+            "agents",
+            set_tracing_disabled=lambda _value: order.append("agents"),
+            set_tracing_export_api_key=lambda _value: order.append("agents"),
+        ),
+        "agency_swarm": module("agency_swarm", Agency=Agency),
+        "agency_swarm.tools": module("agency_swarm.tools", Handoff=object, SendMessage=object),
+        "orchestrator": module("orchestrator", create_orchestrator=lambda: Agent()),
+        "virtual_assistant": module("virtual_assistant", create_virtual_assistant=lambda: Agent()),
+        "deep_research": module("deep_research", create_deep_research=lambda: Agent()),
+        "data_analyst_agent": module("data_analyst_agent", create_data_analyst=lambda: Agent()),
+        "slides_agent": module("slides_agent", create_slides_agent=lambda: Agent()),
+        "docs_agent": module("docs_agent", create_docs_agent=lambda: Agent()),
+        "video_generation_agent": module("video_generation_agent", create_video_generation_agent=lambda: Agent()),
+        "image_generation_agent": module("image_generation_agent", create_image_generation_agent=lambda: Agent()),
+        "patches": patches,
+        "patches.patch_ipython_interpreter_composio": module(
+            "patches.patch_ipython_interpreter_composio",
+            apply_ipython_composio_context_patch=lambda: order.append("patch"),
+        ),
+        "patches.patch_utf8_file_reads": module(
+            "patches.patch_utf8_file_reads",
+            apply_utf8_file_read_patch=lambda: order.append("patch"),
+        ),
+    }
+
+    spec = importlib.util.spec_from_file_location("__main__", ROOT / "swarm.py")
+    if not spec or not spec.loader:
+        raise RuntimeError("could not load swarm.py main import spec")
+
+    old_key = os.environ.pop("OPENAI_API_KEY", None)
+    old_main = sys.modules.get("__main__")
+    try:
+        with swapped_modules(replacements):
+            swarm = importlib.util.module_from_spec(spec)
+            sys.modules["__main__"] = swarm
+            spec.loader.exec_module(swarm)
+    finally:
+        if old_key is not None:
+            os.environ["OPENAI_API_KEY"] = old_key
+        if old_main is None:
+            sys.modules.pop("__main__", None)
+        else:
+            sys.modules["__main__"] = old_main
+
+    if "product-env" not in order:
+        raise RuntimeError(f"swarm.py main did not configure OpenSwarm product env: {order}")
+    if order.index("product-env") < order.index("dotenv"):
+        raise RuntimeError(f"swarm.py configured product env before loading state dotenv: {order}")
+    if order.index("product-env") > order.index("tui"):
+        raise RuntimeError(f"swarm.py configured product env after TUI start: {order}")
 
 
 def smoke_product_state_root_env() -> None:
@@ -161,6 +263,19 @@ def smoke_product_state_root_env() -> None:
                 run_utils._load_openswarm_dotenv(override=True)
                 if os.environ.get("OPENAI_API_KEY") != "state-openai-updated":
                     raise RuntimeError("OpenSwarm post-onboarding dotenv refresh did not replace stale process values")
+
+                with clean_marketplace_env({
+                    "OPENSWARM_MARKETPLACE_SWARM_ID": "someone/custom-swarm",
+                    "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID": "VRSEN/OpenSwarm",
+                    "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
+                }):
+                    values = run_utils._product_env_from_config()
+                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
+                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env swarm id")
+                if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
+                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env parent swarm id")
+                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
+                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env origin")
         finally:
             os.chdir(old_cwd)
             if old_state is None:
@@ -209,6 +324,10 @@ def smoke_product_state_root_env() -> None:
             (ROOT / "openswarm.config.mjs").read_text(encoding="utf-8"),
             encoding="utf-8",
         )
+        (userbase / "openswarm.marketplace.json").write_text(
+            (ROOT / "openswarm.marketplace.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
         (userbase / "openswarm.product-env.json").write_text(
             (ROOT / "openswarm.product-env.json").read_text(encoding="utf-8"),
             encoding="utf-8",
@@ -221,30 +340,140 @@ def smoke_product_state_root_env() -> None:
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
             patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env(),
         ):
             values = run_utils._product_env_from_config()
         if values.get("AGENTSWARM_PRODUCT_DISPLAY_NAME") != "OpenSwarm":
             raise RuntimeError("OpenSwarm Python path loaded wrong fallback product config from site.USER_BASE")
         if values.get("AGENTSWARM_PRODUCT_VERSION") != "9.8.7-userbase":
             raise RuntimeError("OpenSwarm Python fallback product env did not send the package version")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback product env did not send marketplace metadata")
 
         with (
             patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
             patch.object(run_utils.sys, "prefix", str(prefix)),
             patch.object(run_utils.site, "USER_BASE", str(userbase)),
             patch.object(run_utils.shutil, "which", lambda _name: None),
-            patch.dict(
-                os.environ,
-                {
-                    "AGENTSWARM_PRODUCT_VERSION": "stale-parent-version",
-                    "OPENSWARM_STATE_ROOT": str(base / "state"),
-                },
-                clear=False,
-            ),
+            patch.dict(os.environ, {"AGENTSWARM_PRODUCT_VERSION": "stale-parent-version", "OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "AGENTSWARM_MARKETPLACE_SWARM_ID": "stale/swarm",
+                "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID": "stale/parent",
+                "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
+            }),
         ):
             run_utils._configure_product_env()
             if os.environ.get("AGENTSWARM_PRODUCT_VERSION") != "9.8.7-userbase":
                 raise RuntimeError("OpenSwarm Python fallback product env preserved a stale parent version")
+            if os.environ.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+                raise RuntimeError("OpenSwarm Python fallback product env preserved a stale marketplace swarm id")
+            if os.environ.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
+                raise RuntimeError("OpenSwarm Python fallback product env preserved a stale marketplace origin")
+            if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in os.environ:
+                raise RuntimeError("OpenSwarm Python fallback product env preserved a stale marketplace parent id")
+
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "OPENSWARM_MARKETPLACE_SWARM_ID": "someone/custom-swarm",
+                "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID": "VRSEN/OpenSwarm",
+                "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
+                "AGENTSWARM_MARKETPLACE_SWARM_ID": "stale/swarm",
+                "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID": "stale/parent",
+                "AGENTSWARM_MARKETPLACE_SWARM_ORIGIN": "unknown",
+            }),
+        ):
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
+            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env parent swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
+            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env origin")
+
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "OPENSWARM_MARKETPLACE_SWARM_ID": "someone/custom-swarm",
+                "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID": "",
+                "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "original",
+            }),
+        ):
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
+            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env with empty parent")
+        if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in values:
+            raise RuntimeError("OpenSwarm Python fallback preserved empty marketplace parent")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
+            raise RuntimeError("OpenSwarm Python fallback ignored marketplace origin with empty parent")
+
+        full_owner = "a" * 39
+        full_repo = "b" * 100
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "OPENSWARM_MARKETPLACE_SWARM_ID": f"{full_owner}/{full_repo}",
+                "OPENSWARM_MARKETPLACE_PARENT_SWARM_ID": "VRSEN/OpenSwarm",
+                "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
+            }),
+        ):
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != f"{full_owner}/{full_repo}":
+            raise RuntimeError("OpenSwarm Python fallback rejected a full-length marketplace env")
+        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback ignored full-length marketplace parent")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
+            raise RuntimeError("OpenSwarm Python fallback ignored full-length marketplace origin")
+
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "OPENSWARM_MARKETPLACE_SWARM_ID": "someone/custom-swarm",
+                "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
+            }),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "parentSwarmId is required" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted fork marketplace env without a parent")
+
+        with (
+            patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(prefix)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+            clean_marketplace_env({
+                "OPENSWARM_MARKETPLACE_SWARM_ID": f"owner/{'a' * 129}",
+                "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "original",
+            }),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "GitHub owner/repo" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted overlong marketplace env")
 
         early = base / "early-root"
         later = base / "later-root"
@@ -252,6 +481,10 @@ def smoke_product_state_root_env() -> None:
         later.mkdir()
         (early / "openswarm.product-env.json").write_text(
             (ROOT / "openswarm.product-env.json").read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        (early / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"someone/custom-swarm","parentSwarmId":"VRSEN/OpenSwarm","swarmOrigin":"fork"}\n',
             encoding="utf-8",
         )
         (early / "package.json").write_text('{"version":"4.5.6-fallback"}\n', encoding="utf-8")
@@ -271,6 +504,101 @@ def smoke_product_state_root_env() -> None:
             values = run_utils._product_env_from_config()
         if values.get("AGENTSWARM_PRODUCT_VERSION") != "4.5.6-fallback":
             raise RuntimeError("OpenSwarm Python fallback product env used package metadata from another root")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
+            raise RuntimeError("OpenSwarm Python fallback did not use fork marketplace swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback did not use fork marketplace parent swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
+            raise RuntimeError("OpenSwarm Python fallback did not use fork marketplace origin")
+
+        (early / "openswarm.marketplace.json").write_text('{"swarmId":"","swarmOrigin":"fork"}\n', encoding="utf-8")
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "OpenSwarm marketplace metadata" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted malformed marketplace metadata")
+
+        (early / "openswarm.marketplace.json").write_text('{"swarmId":"openswarm","swarmOrigin":"fork"}\n', encoding="utf-8")
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "GitHub owner/repo" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted non-GitHub marketplace metadata")
+
+        (early / "openswarm.marketplace.json").write_text(
+            f'{{"swarmId":"owner/{"a" * 129}","swarmOrigin":"original"}}\n',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "GitHub owner/repo" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted overlong marketplace metadata")
+
+        (early / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"someone/custom-swarm","swarmOrigin":"fork"}\n',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "parentSwarmId is required" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted fork marketplace metadata without a parent")
+
+        (early / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"someone/custom-swarm","parentSwarmId":"VRSEN/OpenSwarm","swarmOrigin":"copy"}\n',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "swarmOrigin must be original, fork, or unknown" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted malformed marketplace origin")
 
 
 def smoke_python_openswarm_tui_binary_resolution() -> None:
@@ -537,6 +865,7 @@ def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
 
 def main() -> int:
     smoke_swarm_import_skips_bootstrap()
+    smoke_swarm_main_configures_product_env()
     smoke_product_state_root_env()
     smoke_python_openswarm_tui_binary_resolution()
     smoke_bootstrap_node_setup_installs_slides_dependencies()

--- a/scripts/smoke-bootstrap.py
+++ b/scripts/smoke-bootstrap.py
@@ -569,6 +569,25 @@ def smoke_product_state_root_env() -> None:
                 raise RuntimeError("OpenSwarm Python fallback accepted invalid GitHub owner metadata")
 
         (early / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"someone/custom-swarm.git","swarmOrigin":"original"}\n',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "GitHub owner/repo" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted .git marketplace metadata")
+
+        (early / "openswarm.marketplace.json").write_text(
             f'{{"swarmId":"owner/{"a" * 129}","swarmOrigin":"original"}}\n',
             encoding="utf-8",
         )

--- a/scripts/smoke-bootstrap.py
+++ b/scripts/smoke-bootstrap.py
@@ -65,9 +65,7 @@ def module(name: str, **attrs: object) -> types.ModuleType:
     return mod
 
 
-def smoke_swarm_import_skips_bootstrap() -> None:
-    order: list[str] = []
-
+def swarm_replacements(order: list[str], *, include_agency: bool = False) -> dict[str, types.ModuleType]:
     patches = module("patches", __path__=[])
     replacements = {
         "run_utils": module(
@@ -93,6 +91,38 @@ def smoke_swarm_import_skips_bootstrap() -> None:
             apply_utf8_file_read_patch=lambda: order.append("patch"),
         ),
     }
+    if not include_agency:
+        return replacements
+
+    class Agent:
+        def __gt__(self, other: object) -> tuple[object, object]:
+            return (self, other)
+
+    class Agency:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            order.append("agency")
+
+        def tui(self, **kwargs: object) -> None:
+            order.append("tui")
+
+    replacements.update({
+        "agency_swarm": module("agency_swarm", Agency=Agency),
+        "agency_swarm.tools": module("agency_swarm.tools", Handoff=object, SendMessage=object),
+        "orchestrator": module("orchestrator", create_orchestrator=lambda: Agent()),
+        "virtual_assistant": module("virtual_assistant", create_virtual_assistant=lambda: Agent()),
+        "deep_research": module("deep_research", create_deep_research=lambda: Agent()),
+        "data_analyst_agent": module("data_analyst_agent", create_data_analyst=lambda: Agent()),
+        "slides_agent": module("slides_agent", create_slides_agent=lambda: Agent()),
+        "docs_agent": module("docs_agent", create_docs_agent=lambda: Agent()),
+        "video_generation_agent": module("video_generation_agent", create_video_generation_agent=lambda: Agent()),
+        "image_generation_agent": module("image_generation_agent", create_image_generation_agent=lambda: Agent()),
+    })
+    return replacements
+
+
+def smoke_swarm_import_skips_bootstrap() -> None:
+    order: list[str] = []
+    replacements = swarm_replacements(order)
 
     spec = importlib.util.spec_from_file_location("swarm_bootstrap_smoke", ROOT / "swarm.py")
     if not spec or not spec.loader:
@@ -110,60 +140,44 @@ def smoke_swarm_import_skips_bootstrap() -> None:
 
     if "bootstrap" in order:
         raise RuntimeError(f"swarm.py ran bootstrap during import: {order}")
+    if "product-env" in order:
+        raise RuntimeError(f"swarm.py configured product env during import instead of agency creation: {order}")
     if not order or order[0] != "dotenv":
         raise RuntimeError(f"swarm.py did not configure runtime during import: {order}")
 
 
+def smoke_swarm_create_agency_configures_product_env() -> None:
+    order: list[str] = []
+    replacements = swarm_replacements(order, include_agency=True)
+
+    spec = importlib.util.spec_from_file_location("swarm_create_agency_smoke", ROOT / "swarm.py")
+    if not spec or not spec.loader:
+        raise RuntimeError("could not load swarm.py create_agency import spec")
+
+    old_key = os.environ.pop("OPENAI_API_KEY", None)
+    try:
+        with swapped_modules(replacements):
+            swarm = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(swarm)
+            swarm.create_agency()
+    finally:
+        if old_key is not None:
+            os.environ["OPENAI_API_KEY"] = old_key
+        sys.modules.pop("swarm_create_agency_smoke", None)
+
+    if "bootstrap" in order:
+        raise RuntimeError(f"swarm.py ran bootstrap during imported create_agency flow: {order}")
+    if "product-env" not in order:
+        raise RuntimeError(f"swarm.py create_agency did not configure OpenSwarm product env: {order}")
+    if order.index("product-env") < order.index("dotenv"):
+        raise RuntimeError(f"swarm.py create_agency configured product env before loading state dotenv: {order}")
+    if order.index("product-env") > order.index("agency"):
+        raise RuntimeError(f"swarm.py create_agency configured product env after agency creation: {order}")
+
+
 def smoke_swarm_main_configures_product_env() -> None:
     order: list[str] = []
-
-    class Agent:
-        def __gt__(self, other: object) -> tuple[object, object]:
-            return (self, other)
-
-    class Agency:
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            order.append("agency")
-
-        def tui(self, **kwargs: object) -> None:
-            order.append("tui")
-
-    patches = module("patches", __path__=[])
-    replacements = {
-        "run_utils": module(
-            "run_utils",
-            _bootstrap=lambda: order.append("bootstrap"),
-            _configure_product_env=lambda: order.append("product-env"),
-            _openswarm_state_root=lambda: ROOT,
-            _preload_agentswarm_bin=lambda: order.append("preload"),
-        ),
-        "dotenv": module("dotenv", load_dotenv=lambda *args, **kwargs: order.append("dotenv")),
-        "agents": module(
-            "agents",
-            set_tracing_disabled=lambda _value: order.append("agents"),
-            set_tracing_export_api_key=lambda _value: order.append("agents"),
-        ),
-        "agency_swarm": module("agency_swarm", Agency=Agency),
-        "agency_swarm.tools": module("agency_swarm.tools", Handoff=object, SendMessage=object),
-        "orchestrator": module("orchestrator", create_orchestrator=lambda: Agent()),
-        "virtual_assistant": module("virtual_assistant", create_virtual_assistant=lambda: Agent()),
-        "deep_research": module("deep_research", create_deep_research=lambda: Agent()),
-        "data_analyst_agent": module("data_analyst_agent", create_data_analyst=lambda: Agent()),
-        "slides_agent": module("slides_agent", create_slides_agent=lambda: Agent()),
-        "docs_agent": module("docs_agent", create_docs_agent=lambda: Agent()),
-        "video_generation_agent": module("video_generation_agent", create_video_generation_agent=lambda: Agent()),
-        "image_generation_agent": module("image_generation_agent", create_image_generation_agent=lambda: Agent()),
-        "patches": patches,
-        "patches.patch_ipython_interpreter_composio": module(
-            "patches.patch_ipython_interpreter_composio",
-            apply_ipython_composio_context_patch=lambda: order.append("patch"),
-        ),
-        "patches.patch_utf8_file_reads": module(
-            "patches.patch_utf8_file_reads",
-            apply_utf8_file_read_patch=lambda: order.append("patch"),
-        ),
-    }
-
+    replacements = swarm_replacements(order, include_agency=True)
     spec = importlib.util.spec_from_file_location("__main__", ROOT / "swarm.py")
     if not spec or not spec.loader:
         raise RuntimeError("could not load swarm.py main import spec")
@@ -270,12 +284,12 @@ def smoke_product_state_root_env() -> None:
                     "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
                 }):
                     values = run_utils._product_env_from_config()
-                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
-                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env swarm id")
-                if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
-                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env parent swarm id")
-                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
-                    raise RuntimeError("OpenSwarm Python Node config ignored marketplace env origin")
+                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+                    raise RuntimeError("OpenSwarm Python Node config allowed ambient marketplace env swarm id")
+                if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in values:
+                    raise RuntimeError("OpenSwarm Python Node config allowed ambient marketplace env parent swarm id")
+                if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
+                    raise RuntimeError("OpenSwarm Python Node config allowed ambient marketplace env origin")
         finally:
             os.chdir(old_cwd)
             if old_state is None:
@@ -388,12 +402,12 @@ def smoke_product_state_root_env() -> None:
             }),
         ):
             values = run_utils._product_env_from_config()
-        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
-            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env swarm id")
-        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
-            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env parent swarm id")
-        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
-            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env origin")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient marketplace env swarm id")
+        if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in values:
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient marketplace env parent swarm id")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient marketplace env origin")
 
         with (
             patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
@@ -408,12 +422,12 @@ def smoke_product_state_root_env() -> None:
             }),
         ):
             values = run_utils._product_env_from_config()
-        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "someone/custom-swarm":
-            raise RuntimeError("OpenSwarm Python fallback ignored marketplace env with empty parent")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient marketplace env with empty parent")
         if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in values:
-            raise RuntimeError("OpenSwarm Python fallback preserved empty marketplace parent")
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient empty marketplace parent")
         if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
-            raise RuntimeError("OpenSwarm Python fallback ignored marketplace origin with empty parent")
+            raise RuntimeError("OpenSwarm Python fallback allowed ambient marketplace origin with empty parent")
 
         full_owner = "a" * 39
         full_repo = "b" * 100
@@ -430,12 +444,12 @@ def smoke_product_state_root_env() -> None:
             }),
         ):
             values = run_utils._product_env_from_config()
-        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != f"{full_owner}/{full_repo}":
-            raise RuntimeError("OpenSwarm Python fallback rejected a full-length marketplace env")
-        if values.get("AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID") != "VRSEN/OpenSwarm":
-            raise RuntimeError("OpenSwarm Python fallback ignored full-length marketplace parent")
-        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "fork":
-            raise RuntimeError("OpenSwarm Python fallback ignored full-length marketplace origin")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback allowed full-length ambient marketplace env")
+        if "AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID" in values:
+            raise RuntimeError("OpenSwarm Python fallback allowed full-length ambient marketplace parent")
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ORIGIN") != "original":
+            raise RuntimeError("OpenSwarm Python fallback allowed full-length ambient marketplace origin")
 
         with (
             patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
@@ -448,13 +462,9 @@ def smoke_product_state_root_env() -> None:
                 "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "fork",
             }),
         ):
-            try:
-                run_utils._product_env_from_config()
-            except RuntimeError as exc:
-                if "parentSwarmId is required" not in str(exc):
-                    raise
-            else:
-                raise RuntimeError("OpenSwarm Python fallback accepted fork marketplace env without a parent")
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback allowed malformed ambient marketplace env")
 
         with (
             patch.object(run_utils, "__file__", str(module_dir / "run_utils.py")),
@@ -467,13 +477,9 @@ def smoke_product_state_root_env() -> None:
                 "OPENSWARM_MARKETPLACE_SWARM_ORIGIN": "original",
             }),
         ):
-            try:
-                run_utils._product_env_from_config()
-            except RuntimeError as exc:
-                if "GitHub owner/repo" not in str(exc):
-                    raise
-            else:
-                raise RuntimeError("OpenSwarm Python fallback accepted overlong marketplace env")
+            values = run_utils._product_env_from_config()
+        if values.get("AGENTSWARM_MARKETPLACE_SWARM_ID") != "VRSEN/OpenSwarm":
+            raise RuntimeError("OpenSwarm Python fallback allowed overlong ambient marketplace env")
 
         early = base / "early-root"
         later = base / "later-root"
@@ -542,6 +548,25 @@ def smoke_product_state_root_env() -> None:
                     raise
             else:
                 raise RuntimeError("OpenSwarm Python fallback accepted non-GitHub marketplace metadata")
+
+        (early / "openswarm.marketplace.json").write_text(
+            '{"swarmId":"bad--owner/custom-swarm","swarmOrigin":"original"}\n',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(run_utils, "__file__", str(early / "run_utils.py")),
+            patch.object(run_utils.sys, "prefix", str(later)),
+            patch.object(run_utils.site, "USER_BASE", str(userbase)),
+            patch.object(run_utils.shutil, "which", lambda _name: None),
+            patch.dict(os.environ, {"OPENSWARM_STATE_ROOT": str(base / "state")}, clear=False),
+        ):
+            try:
+                run_utils._product_env_from_config()
+            except RuntimeError as exc:
+                if "GitHub owner/repo" not in str(exc):
+                    raise
+            else:
+                raise RuntimeError("OpenSwarm Python fallback accepted invalid GitHub owner metadata")
 
         (early / "openswarm.marketplace.json").write_text(
             f'{{"swarmId":"owner/{"a" * 129}","swarmOrigin":"original"}}\n',
@@ -865,6 +890,7 @@ def smoke_bootstrap_node_setup_installs_slides_dependencies() -> None:
 
 def main() -> int:
     smoke_swarm_import_skips_bootstrap()
+    smoke_swarm_create_agency_configures_product_env()
     smoke_swarm_main_configures_product_env()
     smoke_product_state_root_env()
     smoke_python_openswarm_tui_binary_resolution()

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -12,8 +12,25 @@ const { pathToFileURL } = require('url')
 const root = path.dirname(__dirname)
 const launcher = path.join(root, 'bin', 'openswarm')
 const configPath = path.join(root, 'openswarm.config.mjs')
+const marketplacePath = path.join(root, 'openswarm.marketplace.json')
 const productEnvPath = path.join(root, 'openswarm.product-env.json')
 const envWriter = path.join(root, 'scripts', 'write-product-env.mjs')
+const marketplaceEnvKeys = [
+  'OPENSWARM_MARKETPLACE_SWARM_ID',
+  'OPENSWARM_MARKETPLACE_PARENT_SWARM_ID',
+  'OPENSWARM_MARKETPLACE_SWARM_ORIGIN',
+  'AGENTSWARM_MARKETPLACE_SWARM_ID',
+  'AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID',
+  'AGENTSWARM_MARKETPLACE_SWARM_ORIGIN',
+]
+
+function cleanEnv(extra = {}) {
+  const env = { ...process.env, ...extra }
+  for (const key of marketplaceEnvKeys) {
+    if (!(key in extra)) delete env[key]
+  }
+  return env
+}
 
 async function loadConfig() {
   return import(pathToFileURL(configPath).href)
@@ -183,19 +200,60 @@ async function assertStateRoot() {
   assert.equal(env.AGENTSWARM_PRODUCT_DISPLAY_NAME, 'OpenSwarm')
   assert.equal(env.AGENTSWARM_PRODUCT_STATE_ROOT, path.join('/home/tester', '.openswarm'))
   assert.equal(env.AGENTSWARM_PRODUCT_VERSION, pkg.version)
-  assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'openswarm')
+  assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'VRSEN/OpenSwarm')
   assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
   assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
   assertProductAddons(env)
 
+  const forkEnv = config.getProductEnv({
+    env: {
+      OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
+      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+      AGENTSWARM_MARKETPLACE_SWARM_ID: 'stale/swarm',
+      AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: 'stale/parent',
+      AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: 'unknown',
+    },
+    stateRoot: path.join('/home/tester', '.openswarm'),
+  })
+  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+
+  const originalEnv = config.getProductEnv({
+    env: {
+      OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: '',
+      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
+    },
+    stateRoot: path.join('/home/tester', '.openswarm'),
+  })
+  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
+  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
+
+  const fullOwner = 'a'.repeat(39)
+  const fullRepo = 'b'.repeat(100)
+  const fullEnv = config.getProductEnv({
+    env: {
+      OPENSWARM_MARKETPLACE_SWARM_ID: `${fullOwner}/${fullRepo}`,
+      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
+      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+    },
+    stateRoot: path.join('/home/tester', '.openswarm'),
+  })
+  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, `${fullOwner}/${fullRepo}`)
+  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+
   const originalParent = config.product.marketplaceParentSwarmId
-  config.product.marketplaceParentSwarmId = 'parent-swarm'
+  config.product.marketplaceParentSwarmId = 'owner/parent-swarm'
   try {
     const forkEnv = config.getProductEnv({
       env: {},
       stateRoot: path.join('/home/tester', '.openswarm'),
     })
-    assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'parent-swarm')
+    assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'owner/parent-swarm')
   } finally {
     config.product.marketplaceParentSwarmId = originalParent
   }
@@ -207,6 +265,11 @@ async function assertProductEnvJsonSync() {
   const checkedIn = fs.readFileSync(productEnvPath, 'utf8')
   const generated = cp.spawnSync(process.execPath, [envWriter, '--json'], {
     cwd: root,
+    env: cleanEnv({
+      OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
+      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+    }),
     encoding: 'utf8',
   })
   assert.equal(generated.status, 0, `env JSON writer exited with ${generated.status}: ${generated.stderr}`)
@@ -224,7 +287,7 @@ async function assertProductEnvJsonSync() {
   assert.equal(config.getProductEnv({ env: {}, stateRoot: '__OPENSWARM_STATE_ROOT__' }).AGENTSWARM_PRODUCT_VERSION, pkg.version)
 }
 
-function writeFakePackage(rootDir) {
+function writeFakePackage(rootDir, marketplace) {
   const pkg = path.join(rootDir, 'node_modules', '@vrsen', 'openswarm')
   const bin = path.join(pkg, 'bin')
   const dep = path.join(pkg, 'node_modules', '@vrsen', 'agentswarm', 'bin')
@@ -235,6 +298,11 @@ function writeFakePackage(rootDir) {
   fs.copyFileSync(launcher, path.join(bin, 'openswarm'))
   fs.chmodSync(path.join(bin, 'openswarm'), 0o755)
   fs.copyFileSync(configPath, path.join(pkg, 'openswarm.config.mjs'))
+  if (marketplace) {
+    fs.writeFileSync(path.join(pkg, 'openswarm.marketplace.json'), `${JSON.stringify(marketplace, null, 2)}\n`, 'utf8')
+  } else {
+    fs.copyFileSync(marketplacePath, path.join(pkg, 'openswarm.marketplace.json'))
+  }
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify({ name: '@vrsen/openswarm', version: '7.8.9-smoke' }),
@@ -276,14 +344,14 @@ function assertLauncherDelegatesToDependency() {
     const envPath = path.join(tmp, 'env.json')
     const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
       cwd: tmp,
-      env: {
-        ...process.env,
+      env: cleanEnv({
         ENABLE_TELEMETRY: '0',
         OPEN_SWARM_TELEMETRY: '1',
         AGENTSWARM_TELEMETRY: 'true',
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: 'stale/parent',
         OPENSWARM_TUI_URL: 'https://127.0.0.1:9/should-not-be-read',
         OPENSWARM_LAUNCHER_SMOKE_ENV: envPath,
-      },
+      }),
       encoding: 'utf8',
     })
     assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
@@ -293,7 +361,7 @@ function assertLauncherDelegatesToDependency() {
     assert.equal(env.AGENTSWARM_PRODUCT_DISPLAY_NAME, 'OpenSwarm')
     assert.equal(env.AGENTSWARM_PRODUCT_COMMAND, 'openswarm')
     assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
-    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'openswarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'VRSEN/OpenSwarm')
     assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
     assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
     assert.equal(env.AGENTSWARM_LAUNCHER, '1')
@@ -309,12 +377,155 @@ function assertLauncherDelegatesToDependency() {
   }
 }
 
+function assertLauncherPassesForkMarketplaceMetadata() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-fork-marketplace-'))
+  try {
+    const bin = writeFakePackage(tmp, {
+      swarmId: 'someone/custom-swarm',
+      parentSwarmId: 'VRSEN/OpenSwarm',
+      swarmOrigin: 'fork',
+    })
+    const envPath = path.join(tmp, 'env.json')
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: tmp,
+      env: cleanEnv({ OPENSWARM_LAUNCHER_SMOKE_ENV: envPath }),
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
+    const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+    assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertLauncherTreatsEmptyParentEnvAsAbsent() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-empty-parent-env-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const envPath = path.join(tmp, 'env.json')
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: tmp,
+      env: cleanEnv({
+        OPENSWARM_LAUNCHER_SMOKE_ENV: envPath,
+        OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+        OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: '',
+        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: 'stale/parent',
+      }),
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
+    const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertLauncherPassesMarketplaceEnvOverride() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-marketplace-env-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const envPath = path.join(tmp, 'env.json')
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: tmp,
+      env: cleanEnv({
+        OPENSWARM_LAUNCHER_SMOKE_ENV: envPath,
+        OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+        OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
+        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+        AGENTSWARM_MARKETPLACE_SWARM_ID: 'stale/swarm',
+        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: 'stale/parent',
+        AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: 'unknown',
+      }),
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
+    const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+    assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertMalformedMarketplaceMetadataFails() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-bad-marketplace-'))
+  try {
+    for (const marketplace of [
+      { swarmId: '', swarmOrigin: 'fork' },
+      { swarmId: 'openswarm', swarmOrigin: 'fork' },
+      { swarmId: `owner/${'a'.repeat(129)}`, swarmOrigin: 'original' },
+      { swarmId: 'someone/custom-swarm', swarmOrigin: 'fork' },
+      { swarmId: 'someone/custom-swarm', parentSwarmId: 'VRSEN/OpenSwarm', swarmOrigin: 'copy' },
+    ]) {
+      const bin = writeFakePackage(tmp, marketplace)
+      const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+        cwd: tmp,
+        env: cleanEnv(),
+        encoding: 'utf8',
+      })
+      assert.notEqual(result.status, 0, `launcher succeeded with malformed marketplace metadata: ${JSON.stringify(marketplace)}`)
+      assert.ok(result.stderr.includes('OpenSwarm marketplace metadata'), result.stderr)
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertMalformedMarketplaceEnvFails() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-bad-marketplace-env-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: tmp,
+      env: cleanEnv({
+        OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+      }),
+      encoding: 'utf8',
+    })
+    assert.notEqual(result.status, 0, 'launcher succeeded with malformed marketplace env')
+    assert.ok(result.stderr.includes('OpenSwarm marketplace metadata'), result.stderr)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertLongMarketplaceEnvFails() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-long-marketplace-env-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: tmp,
+      env: cleanEnv({
+        OPENSWARM_MARKETPLACE_SWARM_ID: `owner/${'a'.repeat(129)}`,
+        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
+      }),
+      encoding: 'utf8',
+    })
+    assert.notEqual(result.status, 0, 'launcher succeeded with overlong marketplace env')
+    assert.ok(result.stderr.includes('GitHub owner/repo'), result.stderr)
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
 function assertVersionRequestUsesOpenSwarmPackageVersion() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-version-'))
   try {
     const bin = writeFakePackage(tmp)
     const result = cp.spawnSync(process.execPath, [bin, '--version'], {
       cwd: tmp,
+      env: cleanEnv(),
       encoding: 'utf8',
     })
     assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
@@ -334,6 +545,7 @@ function assertMissingPlatformPackageFails() {
     }
     const result = cp.spawnSync(process.execPath, [bin, '--version'], {
       cwd: tmp,
+      env: cleanEnv(),
       encoding: 'utf8',
     })
     assert.notEqual(result.status, 0, 'launcher succeeded without an OpenSwarm platform package')
@@ -347,7 +559,11 @@ function assertWorkflowEnvWriter() {
   const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
   const result = cp.spawnSync(process.execPath, [envWriter], {
     cwd: root,
-    env: process.env,
+    env: cleanEnv({
+      OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
+      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
+      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
+    }),
     encoding: 'utf8',
   })
   assert.equal(result.status, 0, `env writer exited with ${result.status}: ${result.stderr}`)
@@ -364,6 +580,12 @@ async function main() {
   await assertStateRoot()
   await assertProductEnvJsonSync()
   assertLauncherDelegatesToDependency()
+  assertLauncherPassesForkMarketplaceMetadata()
+  assertLauncherPassesMarketplaceEnvOverride()
+  assertLauncherTreatsEmptyParentEnvAsAbsent()
+  assertMalformedMarketplaceMetadataFails()
+  assertMalformedMarketplaceEnvFails()
+  assertLongMarketplaceEnvFails()
   assertVersionRequestUsesOpenSwarmPackageVersion()
   assertMissingPlatformPackageFails()
   assertWorkflowEnvWriter()

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -205,7 +205,7 @@ async function assertStateRoot() {
   assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
   assertProductAddons(env)
 
-  const forkEnv = config.getProductEnv({
+  const ambientEnv = config.getProductEnv({
     env: {
       OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
       OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
@@ -216,37 +216,36 @@ async function assertStateRoot() {
     },
     stateRoot: path.join('/home/tester', '.openswarm'),
   })
-  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
-  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
-  assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
-
-  const originalEnv = config.getProductEnv({
-    env: {
-      OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
-      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: '',
-      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
-    },
-    stateRoot: path.join('/home/tester', '.openswarm'),
-  })
-  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
-  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
-  assert.equal(originalEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
+  assert.equal(ambientEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, 'VRSEN/OpenSwarm')
+  assert.equal(ambientEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
+  assert.equal(ambientEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
 
   const fullOwner = 'a'.repeat(39)
   const fullRepo = 'b'.repeat(100)
-  const fullEnv = config.getProductEnv({
-    env: {
-      OPENSWARM_MARKETPLACE_SWARM_ID: `${fullOwner}/${fullRepo}`,
-      OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
-      OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
-    },
-    stateRoot: path.join('/home/tester', '.openswarm'),
-  })
-  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, `${fullOwner}/${fullRepo}`)
-  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
-  assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
-
+  const originalSwarmId = config.product.marketplaceSwarmId
   const originalParent = config.product.marketplaceParentSwarmId
+  const originalOrigin = config.product.marketplaceSwarmOrigin
+  try {
+    config.product.marketplaceSwarmId = `${fullOwner}/${fullRepo}`
+    config.product.marketplaceSwarmOrigin = 'fork'
+    config.product.marketplaceParentSwarmId = 'VRSEN/OpenSwarm'
+    const fullEnv = config.getProductEnv({
+      env: {
+        OPENSWARM_MARKETPLACE_SWARM_ID: 'ignored/runtime',
+        OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'ignored/runtime-parent',
+        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
+      },
+      stateRoot: path.join('/home/tester', '.openswarm'),
+    })
+    assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ID, `${fullOwner}/${fullRepo}`)
+    assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+    assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+  } finally {
+    config.product.marketplaceSwarmId = originalSwarmId
+    config.product.marketplaceSwarmOrigin = originalOrigin
+    config.product.marketplaceParentSwarmId = originalParent
+  }
+
   config.product.marketplaceParentSwarmId = 'owner/parent-swarm'
   try {
     const forkEnv = config.getProductEnv({
@@ -402,8 +401,8 @@ function assertLauncherPassesForkMarketplaceMetadata() {
   }
 }
 
-function assertLauncherTreatsEmptyParentEnvAsAbsent() {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-empty-parent-env-'))
+function assertLauncherIgnoresMarketplaceEnv() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-ignore-marketplace-env-'))
   try {
     const bin = writeFakePackage(tmp)
     const envPath = path.join(tmp, 'env.json')
@@ -420,7 +419,7 @@ function assertLauncherTreatsEmptyParentEnvAsAbsent() {
     })
     assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
     const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
-    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'VRSEN/OpenSwarm')
     assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
     assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
   } finally {
@@ -428,8 +427,8 @@ function assertLauncherTreatsEmptyParentEnvAsAbsent() {
   }
 }
 
-function assertLauncherPassesMarketplaceEnvOverride() {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-marketplace-env-'))
+function assertLauncherIgnoresMalformedMarketplaceEnv() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-ignore-bad-marketplace-env-'))
   try {
     const bin = writeFakePackage(tmp)
     const envPath = path.join(tmp, 'env.json')
@@ -438,19 +437,15 @@ function assertLauncherPassesMarketplaceEnvOverride() {
       env: cleanEnv({
         OPENSWARM_LAUNCHER_SMOKE_ENV: envPath,
         OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
-        OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'VRSEN/OpenSwarm',
         OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
-        AGENTSWARM_MARKETPLACE_SWARM_ID: 'stale/swarm',
-        AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID: 'stale/parent',
-        AGENTSWARM_MARKETPLACE_SWARM_ORIGIN: 'unknown',
       }),
       encoding: 'utf8',
     })
     assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
     const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
-    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
-    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
-    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'VRSEN/OpenSwarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
     assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
@@ -463,6 +458,7 @@ function assertMalformedMarketplaceMetadataFails() {
     for (const marketplace of [
       { swarmId: '', swarmOrigin: 'fork' },
       { swarmId: 'openswarm', swarmOrigin: 'fork' },
+      { swarmId: 'bad--owner/custom-swarm', swarmOrigin: 'original' },
       { swarmId: `owner/${'a'.repeat(129)}`, swarmOrigin: 'original' },
       { swarmId: 'someone/custom-swarm', swarmOrigin: 'fork' },
       { swarmId: 'someone/custom-swarm', parentSwarmId: 'VRSEN/OpenSwarm', swarmOrigin: 'copy' },
@@ -476,44 +472,6 @@ function assertMalformedMarketplaceMetadataFails() {
       assert.notEqual(result.status, 0, `launcher succeeded with malformed marketplace metadata: ${JSON.stringify(marketplace)}`)
       assert.ok(result.stderr.includes('OpenSwarm marketplace metadata'), result.stderr)
     }
-  } finally {
-    fs.rmSync(tmp, { recursive: true, force: true })
-  }
-}
-
-function assertMalformedMarketplaceEnvFails() {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-bad-marketplace-env-'))
-  try {
-    const bin = writeFakePackage(tmp)
-    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
-      cwd: tmp,
-      env: cleanEnv({
-        OPENSWARM_MARKETPLACE_SWARM_ID: 'someone/custom-swarm',
-        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'fork',
-      }),
-      encoding: 'utf8',
-    })
-    assert.notEqual(result.status, 0, 'launcher succeeded with malformed marketplace env')
-    assert.ok(result.stderr.includes('OpenSwarm marketplace metadata'), result.stderr)
-  } finally {
-    fs.rmSync(tmp, { recursive: true, force: true })
-  }
-}
-
-function assertLongMarketplaceEnvFails() {
-  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-long-marketplace-env-'))
-  try {
-    const bin = writeFakePackage(tmp)
-    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
-      cwd: tmp,
-      env: cleanEnv({
-        OPENSWARM_MARKETPLACE_SWARM_ID: `owner/${'a'.repeat(129)}`,
-        OPENSWARM_MARKETPLACE_SWARM_ORIGIN: 'original',
-      }),
-      encoding: 'utf8',
-    })
-    assert.notEqual(result.status, 0, 'launcher succeeded with overlong marketplace env')
-    assert.ok(result.stderr.includes('GitHub owner/repo'), result.stderr)
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true })
   }
@@ -581,11 +539,9 @@ async function main() {
   await assertProductEnvJsonSync()
   assertLauncherDelegatesToDependency()
   assertLauncherPassesForkMarketplaceMetadata()
-  assertLauncherPassesMarketplaceEnvOverride()
-  assertLauncherTreatsEmptyParentEnvAsAbsent()
+  assertLauncherIgnoresMarketplaceEnv()
+  assertLauncherIgnoresMalformedMarketplaceEnv()
   assertMalformedMarketplaceMetadataFails()
-  assertMalformedMarketplaceEnvFails()
-  assertLongMarketplaceEnvFails()
   assertVersionRequestUsesOpenSwarmPackageVersion()
   assertMissingPlatformPackageFails()
   assertWorkflowEnvWriter()

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -459,7 +459,7 @@ function assertMalformedMarketplaceMetadataFails() {
       { swarmId: '', swarmOrigin: 'fork' },
       { swarmId: 'openswarm', swarmOrigin: 'fork' },
       { swarmId: 'bad--owner/custom-swarm', swarmOrigin: 'original' },
-      { swarmId: 'someone/custom-swarm.git', swarmOrigin: 'original' },
+      { swarmId: 'someone/custom-swarm.GIT', swarmOrigin: 'original' },
       { swarmId: `owner/${'a'.repeat(129)}`, swarmOrigin: 'original' },
       { swarmId: 'someone/custom-swarm', swarmOrigin: 'fork' },
       { swarmId: 'someone/custom-swarm', parentSwarmId: 'VRSEN/OpenSwarm', swarmOrigin: 'copy' },

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -220,16 +220,21 @@ async function assertStateRoot() {
   assert.equal(ambientEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, undefined)
   assert.equal(ambientEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'original')
 
-  const fullOwner = 'a'.repeat(39)
-  const fullRepo = 'b'.repeat(100)
-  const originalSwarmId = config.product.marketplaceSwarmId
-  const originalParent = config.product.marketplaceParentSwarmId
-  const originalOrigin = config.product.marketplaceSwarmOrigin
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-project-marketplace-'))
   try {
-    config.product.marketplaceSwarmId = `${fullOwner}/${fullRepo}`
-    config.product.marketplaceSwarmOrigin = 'fork'
-    config.product.marketplaceParentSwarmId = 'VRSEN/OpenSwarm'
+    const fullOwner = 'a'.repeat(39)
+    const fullRepo = 'b'.repeat(100)
+    fs.writeFileSync(
+      path.join(project, 'openswarm.marketplace.json'),
+      `${JSON.stringify({
+        swarmId: `${fullOwner}/${fullRepo}`,
+        parentSwarmId: 'VRSEN/OpenSwarm',
+        swarmOrigin: 'fork',
+      })}\n`,
+      'utf8',
+    )
     const fullEnv = config.getProductEnv({
+      cwd: project,
       env: {
         OPENSWARM_MARKETPLACE_SWARM_ID: 'ignored/runtime',
         OPENSWARM_MARKETPLACE_PARENT_SWARM_ID: 'ignored/runtime-parent',
@@ -241,20 +246,24 @@ async function assertStateRoot() {
     assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
     assert.equal(fullEnv.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
   } finally {
-    config.product.marketplaceSwarmId = originalSwarmId
-    config.product.marketplaceSwarmOrigin = originalOrigin
-    config.product.marketplaceParentSwarmId = originalParent
+    fs.rmSync(project, { recursive: true, force: true })
   }
 
-  config.product.marketplaceParentSwarmId = 'owner/parent-swarm'
+  const parentProject = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-parent-marketplace-'))
   try {
+    fs.writeFileSync(
+      path.join(parentProject, 'openswarm.marketplace.json'),
+      '{"swarmId":"owner/child-swarm","parentSwarmId":"owner/parent-swarm","swarmOrigin":"fork"}\n',
+      'utf8',
+    )
     const forkEnv = config.getProductEnv({
+      cwd: parentProject,
       env: {},
       stateRoot: path.join('/home/tester', '.openswarm'),
     })
     assert.equal(forkEnv.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'owner/parent-swarm')
   } finally {
-    config.product.marketplaceParentSwarmId = originalParent
+    fs.rmSync(parentProject, { recursive: true, force: true })
   }
 }
 
@@ -393,6 +402,34 @@ function assertLauncherPassesForkMarketplaceMetadata() {
     assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
     const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
     assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/custom-swarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
+    assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+}
+
+function assertLauncherPassesProjectMarketplaceMetadata() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'openswarm-launcher-project-marketplace-'))
+  try {
+    const bin = writeFakePackage(tmp)
+    const project = path.join(tmp, 'project')
+    fs.mkdirSync(project)
+    fs.writeFileSync(
+      path.join(project, 'openswarm.marketplace.json'),
+      '{"swarmId":"someone/project-swarm","parentSwarmId":"VRSEN/OpenSwarm","swarmOrigin":"fork"}\n',
+      'utf8',
+    )
+    const envPath = path.join(tmp, 'env.json')
+    const result = cp.spawnSync(process.execPath, [bin, 'smoke'], {
+      cwd: project,
+      env: cleanEnv({ OPENSWARM_LAUNCHER_SMOKE_ENV: envPath }),
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 0, `launcher exited with ${result.status}: ${result.stderr}`)
+    const env = JSON.parse(fs.readFileSync(envPath, 'utf8'))
+    assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ID, 'someone/project-swarm')
     assert.equal(env.AGENTSWARM_MARKETPLACE_PARENT_SWARM_ID, 'VRSEN/OpenSwarm')
     assert.equal(env.AGENTSWARM_MARKETPLACE_SWARM_ORIGIN, 'fork')
     assert.equal(env.AGENTSWARM_PRODUCT_VERSION, '7.8.9-smoke')
@@ -540,6 +577,7 @@ async function main() {
   await assertProductEnvJsonSync()
   assertLauncherDelegatesToDependency()
   assertLauncherPassesForkMarketplaceMetadata()
+  assertLauncherPassesProjectMarketplaceMetadata()
   assertLauncherIgnoresMarketplaceEnv()
   assertLauncherIgnoresMalformedMarketplaceEnv()
   assertMalformedMarketplaceMetadataFails()

--- a/scripts/smoke-openswarm-launcher.js
+++ b/scripts/smoke-openswarm-launcher.js
@@ -459,6 +459,7 @@ function assertMalformedMarketplaceMetadataFails() {
       { swarmId: '', swarmOrigin: 'fork' },
       { swarmId: 'openswarm', swarmOrigin: 'fork' },
       { swarmId: 'bad--owner/custom-swarm', swarmOrigin: 'original' },
+      { swarmId: 'someone/custom-swarm.git', swarmOrigin: 'original' },
       { swarmId: `owner/${'a'.repeat(129)}`, swarmOrigin: 'original' },
       { swarmId: 'someone/custom-swarm', swarmOrigin: 'fork' },
       { swarmId: 'someone/custom-swarm', parentSwarmId: 'VRSEN/OpenSwarm', swarmOrigin: 'copy' },

--- a/scripts/write-product-env.mjs
+++ b/scripts/write-product-env.mjs
@@ -2,6 +2,7 @@ import { getProductEnv } from "../openswarm.config.mjs"
 
 function stableProductEnv() {
   const env = getProductEnv({
+    env: {},
     stateRoot: "__OPENSWARM_STATE_ROOT__",
   })
   delete env.AGENTSWARM_PRODUCT_STATE_ROOT
@@ -14,7 +15,7 @@ if (process.argv.includes("--json")) {
   process.exit(0)
 }
 
-const env = getProductEnv()
+const env = getProductEnv({ env: {} })
 
 for (const [key, value] of Object.entries(env)) {
   if (key === "AGENTSWARM_PRODUCT_STATE_ROOT") continue

--- a/swarm.py
+++ b/swarm.py
@@ -1,6 +1,6 @@
 import os
 
-from run_utils import _bootstrap, _openswarm_state_root, _preload_agentswarm_bin
+from run_utils import _bootstrap, _configure_product_env, _openswarm_state_root, _preload_agentswarm_bin
 
 _RUNTIME_CONFIGURED = False
 
@@ -36,6 +36,9 @@ if __name__ == "__main__":
     _bootstrap()
 
 _configure_runtime()
+
+if __name__ == "__main__":
+    _configure_product_env()
 
 
 def create_agency(load_threads_callback=None):

--- a/swarm.py
+++ b/swarm.py
@@ -37,12 +37,10 @@ if __name__ == "__main__":
 
 _configure_runtime()
 
-if __name__ == "__main__":
-    _configure_product_env()
-
 
 def create_agency(load_threads_callback=None):
     _configure_runtime()
+    _configure_product_env()
 
     from agency_swarm import Agency
     from agency_swarm.tools import Handoff, SendMessage


### PR DESCRIPTION
## Summary

- Adds explicit OpenSwarm marketplace metadata for the official `VRSEN/OpenSwarm` package.
- Uses `openswarm.marketplace.json` as the source of truth for marketplace identity: project-local metadata wins for GitHub fork checkouts, and packaged metadata remains the official fallback.
- Maps validated marketplace identity into the AgentSwarm telemetry environment in the Node launcher, Python source path, and Python fallback path.
- Configures product env during `create_agency()` so the documented `python server.py` path carries marketplace identity.
- Includes marketplace metadata changes in the CI path filters and smoke coverage.

## Notes

- Release and npm publish are intentionally out of scope for this PR.
- OpenSwarm release readiness still depends on an AgentSwarm package version that carries the marketplace telemetry contract.
- Agencii/GitHub publishing should create or patch `openswarm.marketplace.json` in each fork checkout or packaged artifact with the GitHub `owner/repo` marketplace identity.
- The README entrypoint remains the single promoted command: `npx @vrsen/openswarm`.

## Verification

Verified the current diff with launcher, Python source/fallback, wheel fallback, package-inclusion checks, and independent structural review.
