### PR TITLE
chore(release): prepare OpenSwarm 1.0.1-rc.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.9",
+    "version": "1.0.1-rc.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.0.1-rc.9",
+            "version": "1.0.1-rc.10",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.39",
+                "@vrsen/agentswarm": "1.4.40",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -31,18 +31,18 @@
                 "python": ">=3.10"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.9",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.9"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.10",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.10"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -510,21 +510,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.39.tgz",
-            "integrity": "sha512-AUA/5jU6pj2PB/h5C8AeibUUa6zo9MhxrnY32zQy4y1piqOFsI4OERLX9m09egzMuTgjdQkn57waZM0fLdeY5Q==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.40.tgz",
+            "integrity": "sha512-KkR94VaYvNSnSQnGz/UTOW4cim5Cxz4xE/3Q3hCdefe96L5QtF/TM0Uydv9GPUzWhMyhUdwcHiwrT1QmaJTmig==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.39"
+                "agentswarm-cli": "1.4.40"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.39.tgz",
-            "integrity": "sha512-jge2/vH9rS4Ouu4VYDz0vG+EM+Fb3uukNn+haWI0SRIeRIgoO0HOSEamJ0EO7XZhTQOdIqO5heYvm7Y9xNCcdA==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.40.tgz",
+            "integrity": "sha512-QJHwW2BtbnR8u9m/1Ez3O7qtB1CkQgFg5TxtEQFTQ7xiBXk6gaM1EpTeCPo9Oh/KW4fcC9No6FPTeKlQ+3Opzg==",
             "cpu": [
                 "arm64"
             ],
@@ -534,9 +534,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.39.tgz",
-            "integrity": "sha512-GBIclRM+jKWz9RJ8orFNGYptF2k3Omg2hdCGjWOG5ey1iVAkMm/FNf0LBkmh8l341zYFVRnUGYTezphdvI9aJA==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.40.tgz",
+            "integrity": "sha512-lriB1s7t3nRqHC+Ka2Mq3YEZc2mDhyJAi+P0JbFEHL9tD0rCtKhkzIs/4X+RNRyJHdt+7SBqOipzLfoSni+PNw==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.39.tgz",
-            "integrity": "sha512-fFDDYVuh28tmynC91nnyCJFzz3K0gRcMQy6S5bExQG2TadlCOGxKfkKAv4eUM63A5Hu48b/OpQWiocL2mE12Xg==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.40.tgz",
+            "integrity": "sha512-CzbqzES9xxWPSl5OVZrSuJ4NOnq9pG5SWlQPK69Qr5Qz/FYkspWmnoOWdJpyuEQL+vnCA/2I8w3Rl8GeNd5IVA==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.39.tgz",
-            "integrity": "sha512-iMte86kLfXn9wvxojAoT9XHKMtgG1gI1HxpzQ5tJTMgp86sWUjM3EozGQp8sZMK9E4PK/fAZTGJwqymP25tPvw==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.40.tgz",
+            "integrity": "sha512-BJCThI4xG8RuQKWZzF8oh8TTSQJZOjTd3dfuFKYS2VXgVQfVG/OrKnuN/Fz4ticjnkwOMwTtPFyqLM3g8a0VJg==",
             "cpu": [
                 "arm64"
             ],
@@ -570,9 +570,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.39.tgz",
-            "integrity": "sha512-GP5+LsnEA1sdhR6tv1HcYTFD0yA8LlYBOEZGbKY+XBx9lg+IHQ44N4fKaQ7GSJ3g10Kq/S+gIZHO0aESjMX2Kw==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.40.tgz",
+            "integrity": "sha512-ColcPWvVu9jeQ5EzsrNXWm9Lm1w0DfaBgARiCoKcAbolV8ZjYr9JHLJJ47XX+tLfgLG7rZJZ4oPJeh1Sk2ZPcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -582,9 +582,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.39.tgz",
-            "integrity": "sha512-3d9iDDZGqrV6Fhmg5GVKv2uen7BftwIhSCVSfYpxoNGakg+sIs4v0d2a5yN1g6w1uJGuoEmfo7IHPIVcU/or4w==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.40.tgz",
+            "integrity": "sha512-OPfEPab3bHnju8DCVVeAp+d+x8z6HrVpfk7GdqoH1I2Eij0M1XvrvocwML2ocXCMt11kaAdU1lx6C4TYLtzLTw==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.39.tgz",
-            "integrity": "sha512-7IYaWS4e2JYI2RYdrHGsydmzpKiF4hx5+sa1wrbyAI7CKA6euVo1rutMS0Np2v/EzGE+2lwBQXtXcO3q2pI41A==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.40.tgz",
+            "integrity": "sha512-mHJLtjCs9+bxrMJp5AXF2gHvhCFdd8v9AzxbE//38SQ4xwadOAAKMPnWnuf5EIv9qhNNha57QvobDWItCLtVmg==",
             "cpu": [
                 "x64"
             ],
@@ -606,9 +606,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.39.tgz",
-            "integrity": "sha512-sQHFOc3oQVXSHuSrdRMJbOfiKIWOMUA/xQrF7NbVzu/TV9RM35b7gXo8xHnwO2Vw/IpCn12TWmnBMCJWEPGJ+w==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.40.tgz",
+            "integrity": "sha512-WWtRONB3Y4TTh2B/Su7rhwuUYfXhSQmGIgG2ZmAkGbxuq4UlKOIhSe903nGKpkAMtvSNvmfDQZInVDYhh8i+3g==",
             "cpu": [
                 "x64"
             ],
@@ -618,9 +618,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.39.tgz",
-            "integrity": "sha512-h6j4y0ZrLcSA4jYGRXYDj782D3TnJkVVEXQ3qtff3+e3fJZzBNJhyn4/S39BYfOZHNFkQ5Q0URSdTWHxpzYYtg==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.40.tgz",
+            "integrity": "sha512-xFYHtVwdWfWSuAs6Y66424P/cSnSmwaPF2eFHih5irOhtp27QmfKyVivRSxf0n48NwO8LwbGu+5hfTwvnvbngg==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +630,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.39.tgz",
-            "integrity": "sha512-SjEKee4g0SJn/pUiIDkhUP5ExAeqlhsm4NT27ad0im0Lrpug0KcN4CxxB2xlnVdVEwpAGOfwVgKDXGL6zKIKBA==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.40.tgz",
+            "integrity": "sha512-x4CXp10xHNsMIQQv+2bHK/bAAYKPvW+cgSTCaZEUTFhAbSnAyxqyN2u49LvfY06dDvlXNKvA5qD4+dCWa45ahQ==",
             "cpu": [
                 "arm64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.39.tgz",
-            "integrity": "sha512-U3oXHfM7rJs+XBhdSTbg5R9Yhec4m1vXBqMo4q3N50V42eUXO0RQb6m7a4nOCcxupUjrOojIxIXTyNTPoVEr0A==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.40.tgz",
+            "integrity": "sha512-rohsLgxcBVVYc9F4C00D8JZd8nH5BIk3EVe/YGw6O19gfv8/2gzydLeQAhmrAFs03EEMsalZAfyFlyscxFYpAw==",
             "cpu": [
                 "x64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.39.tgz",
-            "integrity": "sha512-3XBqVWfj1lTk7DnAHRZGrbD4VNr4OMslog9/8zcfe2zMACElZAbQsT0L26H6XcD1B/gC3BMt2W+ya/qBxP9b/g==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.40.tgz",
+            "integrity": "sha512-l+ymfnd7u8o9A4kfoFqNbkitHhzYFJGCiBvkxRiNVLLAsTFVrUk5TwcwaS3SIIQec5v8zMG3fwLz24DhtdBb2A==",
             "cpu": [
                 "x64"
             ],
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "arm64"
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.0.1-rc.9",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.9.tgz",
+            "version": "1.0.1-rc.10",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.0.1-rc.10.tgz",
             "license": "MIT",
             "cpu": [
                 "x64"
@@ -825,27 +825,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.39",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.39.tgz",
-            "integrity": "sha512-wpS0ROwGMjvabreT9ML69zAcDaEi++vt1btcXMLmQMFt1qLGUt1pZS8mn2KYjJaNbdFi/o4rNeZSFDAVy4i8Yw==",
+            "version": "1.4.40",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.40.tgz",
+            "integrity": "sha512-rBSFPIcR/dtc03ukm3zvzIaTlpwTY91bfhk5DQdZKrsX2LAgwTRAC4pVaoGiBxQiihXdy2op7LYFw4nSkH2otg==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.39",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.39",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.39",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.39",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.39",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.39",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.39"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.40",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.40",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.40",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.40",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.40",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.40",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.40"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.0.1-rc.9",
+    "version": "1.0.1-rc.10",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -41,7 +41,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.39",
+        "@vrsen/agentswarm": "1.4.40",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
@@ -52,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.9",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.9"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-darwin-x64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-arm64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-x64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-windows-arm64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-windows-x64": "1.0.1-rc.10",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.0.1-rc.10"
     },
     "engines": {
         "node": ">=18.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.0.1-rc.9"
+version = "1.0.1-rc.10"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"

--- a/scripts/smoke-run-mode.py
+++ b/scripts/smoke-run-mode.py
@@ -310,7 +310,10 @@ def run_tui_smoke(
             if "failedtostartresponsestream" in lower_compact or "cannotreachagency-swarmbackend" in lower_compact:
                 raise RuntimeError("OpenSwarm backend became unreachable during smoke test")
 
-            if not sent_confirm and "Createalocal`.venv`inthisproject?" in compact_plain:
+            if not sent_confirm and (
+                "Createalocal`.venv`inthisproject?" in compact_plain
+                or "Createanisolatedprojectenvironment?" in compact_plain
+            ):
                 write(master_fd, "\r")
                 sent_confirm = True
 
@@ -320,7 +323,9 @@ def run_tui_smoke(
                 write(master_fd, "/agents\r")
                 sent_agents_command = True
 
-            if sent_agents_command and not verified_agents and "Selectswarm" in compact_plain:
+            if sent_agents_command and not verified_agents and (
+                "Selectswarm" in compact_plain or "Selectagent" in compact_plain
+            ):
                 missing = [term for term, packed in zip(expected_agent_terms, expected_agent_compact) if packed not in compact_plain]
                 if not missing:
                     verified_agents = True


### PR DESCRIPTION
## Summary

- Bump OpenSwarm release metadata and platform packages to `1.0.1-rc.10`.
- Pin the published AgentSwarm CLI `1.4.40`.
- Update the release smoke harness for AgentSwarm 1.4.40's first-run and agent-picker prompts.

## Why

This release candidate incorporates AgentSwarm CLI 1.4.40 while preserving coverage of OpenSwarm's terminal startup, live prompt, and agent-selection flows.

## Verification

- Version and lockfile consistency checks passed.
- Fresh dependency installation and launcher smoke passed.
- Extracted and packaged binaries report AgentSwarm CLI `1.4.40`.
- Published AgentSwarm and packaged OpenSwarm binaries matched exactly.
- Live prompt smoke passed.
- `/agents` smoke passed with all eight expected agents visible.
- Python bootstrap and wheel-bootstrap smokes passed.
- Packed-package startup passed twice without runtime binary downloads.
- Fresh and preserved release tarballs were byte-identical.
- Current-diff Codex review completed with no findings.
