### PR TITLE
Fix stale unread email tool references

### DIFF
--- a/virtual_assistant/instructions.md
+++ b/virtual_assistant/instructions.md
@@ -66,7 +66,7 @@ Use the available tools like `FindEmails`, `ReadEmail`, `DraftEmail`, `SendDraft
 
 1. User: "Check my unread emails"
 2. `ManageConnections` → Gmail is connected
-3. `CheckUnreadEmails(provider="gmail", limit=10)` → Done!
+3. `FindEmails(provider="gmail", query="is:unread", limit=10)` → Done!
 
 ### Priority 2: Composio Tools (Fallback)
 

--- a/virtual_assistant/tools/AddLabelToEmail.py
+++ b/virtual_assistant/tools/AddLabelToEmail.py
@@ -23,7 +23,7 @@ class AddLabelToEmail(BaseTool):
     
     message_id: str = Field(
         ...,
-        description="The message ID to add labels to (obtained from CheckUnreadEmails)"
+        description="The message ID to add labels to (obtained from FindEmails)"
     )
     
     label_ids: List[str] = Field(
@@ -112,8 +112,8 @@ if __name__ == "__main__":
     print()
     
     # Get a message ID first
-    from virtual_assistant.tools.CheckUnreadEmails import CheckUnreadEmails
-    check_tool = CheckUnreadEmails(provider="gmail", limit=1)
+    from virtual_assistant.tools.FindEmails import FindEmails
+    check_tool = FindEmails(provider="gmail", query="is:unread", limit=1)
     result = check_tool.run()
     
     import json

--- a/virtual_assistant/tools/ReadEmail.py
+++ b/virtual_assistant/tools/ReadEmail.py
@@ -46,7 +46,7 @@ class ReadEmail(BaseTool):
     """
     Reads the full content of a specific email by its message ID.
     
-    Use this after CheckUnreadEmails to fetch the complete email content
+    Use this after FindEmails to fetch the complete email content
     when you need to read the full message body.
     """
     
@@ -57,7 +57,7 @@ class ReadEmail(BaseTool):
     
     message_id: str = Field(
         ...,
-        description="The message ID to fetch (obtained from CheckUnreadEmails)"
+        description="The message ID to fetch (obtained from FindEmails)"
     )
     
     body_format: Literal["text", "html"] = Field(
@@ -190,9 +190,9 @@ if __name__ == "__main__":
     print("=" * 60)
     print()
     
-    # Get a message ID from CheckUnreadEmails
-    from virtual_assistant.tools.CheckUnreadEmails import CheckUnreadEmails
-    check_tool = CheckUnreadEmails(provider="gmail", limit=1)
+    # Get a message ID from FindEmails
+    from virtual_assistant.tools.FindEmails import FindEmails
+    check_tool = FindEmails(provider="gmail", query="is:unread", limit=1)
     result = check_tool.run()
     
     import json
@@ -230,7 +230,7 @@ if __name__ == "__main__":
     # Test 3: Read an Outlook message
     print("Test 3: Outlook - Plain text")
     print("-" * 60)
-    check_tool = CheckUnreadEmails(provider="outlook", limit=1)
+    check_tool = FindEmails(provider="outlook", is_read=False, limit=1)
     result = check_tool.run()
     try:
         data = json.loads(result)

--- a/virtual_assistant/tools/RemoveLabelFromEmail.py
+++ b/virtual_assistant/tools/RemoveLabelFromEmail.py
@@ -25,7 +25,7 @@ class RemoveLabelFromEmail(BaseTool):
     
     message_id: str = Field(
         ...,
-        description="The message ID to remove labels from (obtained from CheckUnreadEmails)"
+        description="The message ID to remove labels from (obtained from FindEmails)"
     )
     
     label_ids: List[str] = Field(


### PR DESCRIPTION
## Summary

- replace stale `CheckUnreadEmails` references with the registered `FindEmails` tool
- use `query="is:unread"` for Gmail unread searches
- use `is_read=False` for Outlook unread searches
- update adjacent message-ID descriptions and executable examples

## Why

The Virtual Assistant instructed the model and local tool examples to call `CheckUnreadEmails`, but that tool does not exist. `FindEmails` is the registered search tool and already supports the required Gmail and Outlook unread filters. The stale guidance could cause failed tool selection and broken standalone examples.

## Validation

- confirmed the parent has 11 `CheckUnreadEmails` references and this commit has zero
- compiled `FindEmails.py`, `ReadEmail.py`, `AddLabelToEmail.py`, and `RemoveLabelFromEmail.py`
- passed `git diff --check`
- completed a clean independent review of commit `92e8d4966a8fa76b217ab3c743b83d8ce61658c5`

No merge or deployment is included in this PR.