### PR TITLE
Release OpenSwarm 1.1.1

### DIFF
--- a/data_analyst_agent/instructions.md
+++ b/data_analyst_agent/instructions.md
@@ -60,12 +60,10 @@ import matplotlib.pyplot as plt
 import os
 
 # Fetch data from external system
-# Composio and user_id are imported at runtime and do not require separate imports
-result = composio.tools.execute(
+# execute_composio_tool is imported at runtime and does not require a separate import
+result = execute_composio_tool(
     "TOOL_NAME_HERE",
-    user_id=user_id,
-    arguments={"param1": "value1"},
-    dangerously_skip_version_check=True
+    {"param1": "value1"},
 )
 
 # Transform to DataFrame

--- a/helpers.py
+++ b/helpers.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 
 from composio import Composio
@@ -10,7 +11,13 @@ _load_openswarm_dotenv()
 _composio_clients: dict[str, Composio] = {}
 
 
+def _refresh_runtime_env() -> None:
+    """Reload add-on keys written through the TUI into the running process."""
+    _load_openswarm_dotenv(override=True)
+
+
 def get_composio_user_id() -> str | None:
+    _refresh_runtime_env()
     for key in ("COMPOSIO_USER_ID", "USER_ID"):
         value = os.getenv(key)
         if value:
@@ -19,6 +26,7 @@ def get_composio_user_id() -> str | None:
 
 
 def get_composio_client() -> Composio | None:
+    _refresh_runtime_env()
     api_key = os.getenv("COMPOSIO_API_KEY")
     if not api_key:
         return None
@@ -37,12 +45,17 @@ def execute_composio_tool(tool_name: str, arguments: dict):
     if not user_id:
         return {"error": "COMPOSIO_USER_ID is not set."}
 
-    return composio.tools.execute(
-        tool_name,
-        user_id=user_id,
-        arguments=arguments,
-        dangerously_skip_version_check=True,
-    )
+    kwargs = {"user_id": user_id, "arguments": arguments}
+    # composio>=0.9.0 checks tool versions on execute; skip it when supported.
+    # Older releases (0.8.x) have no such check and reject the keyword.
+    try:
+        parameters = inspect.signature(composio.tools.execute).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if "dangerously_skip_version_check" in parameters:
+        kwargs["dangerously_skip_version_check"] = True
+
+    return composio.tools.execute(tool_name, **kwargs)
 
 
 def get_composio_tools(**kwargs):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -31,18 +31,18 @@
                 "python": ">=3.12"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.1.0",
-                "@vrsen/openswarm-cli-darwin-x64": "1.1.0",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.0",
-                "@vrsen/openswarm-cli-linux-arm64": "1.1.0",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.0",
-                "@vrsen/openswarm-cli-linux-x64": "1.1.0",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.0",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.0",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.0",
-                "@vrsen/openswarm-cli-windows-arm64": "1.1.0",
-                "@vrsen/openswarm-cli-windows-x64": "1.1.0",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.0"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.1.1",
+                "@vrsen/openswarm-cli-darwin-x64": "1.1.1",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.1",
+                "@vrsen/openswarm-cli-linux-arm64": "1.1.1",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.1",
+                "@vrsen/openswarm-cli-linux-x64": "1.1.1",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.1",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.1",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.1",
+                "@vrsen/openswarm-cli-windows-arm64": "1.1.1",
+                "@vrsen/openswarm-cli-windows-x64": "1.1.1",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.1"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.1.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.1.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.1.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.1.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.0.tgz",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.1.tgz",
             "cpu": [
                 "x64"
             ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -52,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.1.0",
-        "@vrsen/openswarm-cli-darwin-x64": "1.1.0",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.0",
-        "@vrsen/openswarm-cli-linux-arm64": "1.1.0",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.0",
-        "@vrsen/openswarm-cli-linux-x64": "1.1.0",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.0",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.0",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.0",
-        "@vrsen/openswarm-cli-windows-arm64": "1.1.0",
-        "@vrsen/openswarm-cli-windows-x64": "1.1.0",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.0"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.1.1",
+        "@vrsen/openswarm-cli-darwin-x64": "1.1.1",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.1",
+        "@vrsen/openswarm-cli-linux-arm64": "1.1.1",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.1",
+        "@vrsen/openswarm-cli-linux-x64": "1.1.1",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.1",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.1",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.1",
+        "@vrsen/openswarm-cli-windows-arm64": "1.1.1",
+        "@vrsen/openswarm-cli-windows-x64": "1.1.1",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.1"
     },
     "engines": {
         "node": ">=20.0.0",

--- a/patches/patch_ipython_interpreter_composio.py
+++ b/patches/patch_ipython_interpreter_composio.py
@@ -13,7 +13,7 @@ if r"{root_dir}" not in sys.path:
     sys.path.insert(0, r"{root_dir}")
 
 import helpers as _helpers
-from helpers import get_composio_client, get_composio_user_id
+from helpers import execute_composio_tool, get_composio_client, get_composio_user_id
 
 composio = get_composio_client()
 user_id = get_composio_user_id()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "rich",
     "fastapi",
     "uvicorn",
-    "composio==0.8.0",
-    "composio-openai-agents==0.8.0",
+    "composio==0.15.0",
+    "composio-openai-agents==0.15.0",
     "pytz",
     # Data analysis
     "pandas>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.1.0"
+version = "1.1.1"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"
 dependencies = [
-    "agency-swarm[fastapi,jupyter,litellm]==1.10.4",
+    "agency-swarm[fastapi,jupyter,litellm]==1.10.5",
     "questionary>=2.0.0",
     "python-dotenv",
     "rich",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ agency-swarm[fastapi,jupyter,litellm]==1.10.4
 questionary>=2.0.0
 fastapi
 uvicorn
-composio==0.8.0
-composio-openai-agents==0.8.0
+composio==0.15.0
+composio-openai-agents==0.15.0
 pytz
 # Data analysis and manipulation
 pandas>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-agency-swarm[fastapi,jupyter,litellm]==1.10.4
+agency-swarm[fastapi,jupyter,litellm]==1.10.5
 questionary>=2.0.0
 fastapi
 uvicorn

--- a/shared_instructions.md
+++ b/shared_instructions.md
@@ -40,8 +40,8 @@ Agents (except for Agent Swarm agent) can extend their functionality by adding c
 ### 5.3 Advanced queries
 
 - For standard tasks, prefer shared tools (`ManageConnections`, `SearchTools`, `FindTools`, `ExecuteTool`).
-- If `ProgrammaticToolCalling` is unavoidable, direct calls to `composio.tools.execute(...)` and `composio.tools.get(...)` are allowed.
-- In `ProgrammaticToolCalling`, `composio` (the injected Composio client object for `tools.get`/`tools.execute`) and `user_id` are automatically available at runtime.
+- If `ProgrammaticToolCalling` is unavoidable, use `execute_composio_tool(...)` for execution and `composio.tools.get(...)` for discovery.
+- In `ProgrammaticToolCalling`, `execute_composio_tool`, `composio` (the injected Composio client object for `tools.get`), and `user_id` are automatically available at runtime.
 Do not import them manually unless explicitly needed for compatibility.
 
 ```python
@@ -51,15 +51,13 @@ tools = composio.tools.get(
     limit=5,
 )
 
-result = composio.tools.execute(
-    tool_name="GMAIL_SEND_EMAIL",
-    user_id=user_id,
-    arguments={
+result = execute_composio_tool(
+    "GMAIL_SEND_EMAIL",
+    {
         "to": ["user@example.com"],
         "subject": "Hello",
         "body": "Hi from agent",
     },
-    dangerously_skip_version_check=True,
 )
 print(result)
 ```

--- a/virtual_assistant/instructions.md
+++ b/virtual_assistant/instructions.md
@@ -88,13 +88,10 @@ Use `ExecuteTool` for single tool execution without data transformation. Optiona
 Use this option for tasks that require multiple tool calls, data processing, storing intermediate results, or complex logic.
 
 ```python
-from helpers import composio, user_id # only need to be imported in the first tool call
-
-result = composio.tools.execute(
+# execute_composio_tool is automatically available at runtime; no import needed
+result = execute_composio_tool(
     "TOOL_NAME_HERE",
-    user_id=user_id,
-    arguments={"param1": "value1", "param2": "value2"},
-    dangerously_skip_version_check=True
+    {"param1": "value1", "param2": "value2"},
 )
 print(result)
 ```


### PR DESCRIPTION
Patch release delivering the post-1.1.0 QA fixes.

- Restore Composio tool execution: bump `composio`/`composio-openai-agents` pins from 0.8.0 to 0.15.0 (the pinned 0.8.0 does not accept `dangerously_skip_version_check`, so every fresh 1.1.0 install crashed on Composio calls), pass the kwarg only when the installed signature accepts it so existing installs keep working, and fix the documented `tools.execute` call shape.
- Reload Composio keys dynamically: `/addons` keys added mid-session are picked up by later Composio calls, following the existing dynamic-key pattern.
- Pin Agency Swarm 1.10.5, which fixes same-turn chained handoffs (A→B→C and A→B→A stalled at the first recipient).
- Bump the package, lockfile, Python project, and 12 platform packages to 1.1.1.

Verified locally: fresh venv with the new pin set resolves cleanly (152 packages compatible: agency-swarm 1.10.5, composio 0.15.0, openai-agents 0.14.8, litellm 1.91.3); Composio execute-signature checks pass on both old and new composio; launcher smoke and the document-containment regression test pass; agency-swarm 1.10.5 itself shipped with an offline chained-handoff regression test plus a 15-test live-API handoff run. Live Composio execution still needs a real COMPOSIO_API_KEY (not available on this machine) — recommended as post-release QA.