### PR TITLE
Release OpenSwarm 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.41",
+                "@vrsen/agentswarm": "1.4.42",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -31,18 +31,18 @@
                 "python": ">=3.12"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.1.1",
-                "@vrsen/openswarm-cli-darwin-x64": "1.1.1",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.1",
-                "@vrsen/openswarm-cli-linux-arm64": "1.1.1",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.1",
-                "@vrsen/openswarm-cli-linux-x64": "1.1.1",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.1",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.1",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.1",
-                "@vrsen/openswarm-cli-windows-arm64": "1.1.1",
-                "@vrsen/openswarm-cli-windows-x64": "1.1.1",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.1"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.1.2",
+                "@vrsen/openswarm-cli-darwin-x64": "1.1.2",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.2",
+                "@vrsen/openswarm-cli-linux-arm64": "1.1.2",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.2",
+                "@vrsen/openswarm-cli-linux-x64": "1.1.2",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.2",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.2",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.2",
+                "@vrsen/openswarm-cli-windows-arm64": "1.1.2",
+                "@vrsen/openswarm-cli-windows-x64": "1.1.2",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.2"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -510,21 +510,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.41.tgz",
-            "integrity": "sha512-X0RYSA7FfOgS98krlXlYeli1au/C7g2XyxZcXmUMlIabp6xuoSxbieVKWu90551sPH/NxlzGd1xMNRpoeDP9KA==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.42.tgz",
+            "integrity": "sha512-KluvfvHFgepJZFN+83Pi1wmfZ+yBYgdBZjYnk/bVlPTy+yDFPphbMAVijz+O8RMHVS5kir4UOZ0wJtgqjTEjPg==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.41"
+                "agentswarm-cli": "1.4.42"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.41.tgz",
-            "integrity": "sha512-+VYXcpT5EE+/z8UipOqCjx1/3zOtBkfYQBym+LSjDE5L9f8UluXrFWHYtUeep3mOrbAtCE6G4USdcxDm4FSnEQ==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.42.tgz",
+            "integrity": "sha512-m8+Mc9H0xzx214keXh4iE4wsKK6AZg30PvKvK4cDTDAvUTOaoMQMSb5TMhBye18Zs3d0zihe7FdWlQoY0JEtEA==",
             "cpu": [
                 "arm64"
             ],
@@ -534,9 +534,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.41.tgz",
-            "integrity": "sha512-1lBL0KaLAxM3dHYSjtKtT78qJtQyAuskVTFJxXF80ojFglETfZ6UDsUABkdgbUR/Xk61XXda009xKMIP1cAqMw==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.42.tgz",
+            "integrity": "sha512-CII4p0h/dPexQppMA+ScATtxgu7OtuQDzeY7OhnOpy9bWOcLuaBuQulBvZwFa5FKk61Jh6iKxbIrhTKfh+Fqgw==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.41.tgz",
-            "integrity": "sha512-ovln/JBdSbxqdXSS6IVbtlb/MHkt5oGdsb61aI8aMX+oXZSB/7654NcAeQZNSUQyw1okDGTO1jghnR10AgEFOQ==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.42.tgz",
+            "integrity": "sha512-4pPvw79LWuog1MqM/pcJ3EMy5IPYMqf5VlSGL0eZBVjSSZZiWE826OEdWEOI+sqnSWAZ5IoBKrWyXl/VcaqsqA==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.41.tgz",
-            "integrity": "sha512-kxuA4sPm75RFGKoQPxaoE08Pwepq82TU7cWLcBVNJJsjzbSkN7pUs3BpO8t1A9RRdJUwA1Qel75UL7Xz4mpUsw==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.42.tgz",
+            "integrity": "sha512-ag6UGFJXw1yfMjJiaI5/IXmSrh9q8bOro6nwZED8UJkn2eC0EbPVqYkAGlwg2XB+yxFuSMBWifoVYergQt8wBA==",
             "cpu": [
                 "arm64"
             ],
@@ -570,9 +570,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.41.tgz",
-            "integrity": "sha512-XXkdE17wVSSGgbZqfUle0OSwuftIk4kvrBmfKs8VmHAO+uW3arK/VkvG47Ht8is63XgSs1iLiT66YulleEFodQ==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.42.tgz",
+            "integrity": "sha512-9T+6QTNbKFRtdJJJlaDpxcL+bC6ehICfKyClpt62r9TPqTz1xSvc22SCYjAi47/A3zF0GWPy2LuwVnXJ7OZA2w==",
             "cpu": [
                 "arm64"
             ],
@@ -582,9 +582,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.41.tgz",
-            "integrity": "sha512-llA1BfdgFoYcM9VBCxrwv1wvvPEhDDEX8LrcBmmO7QbfiuLw2HFFjsKwIkCJfqleledjIdKxa+7BDYaHaSeRCA==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.42.tgz",
+            "integrity": "sha512-8/pYEr+kETY6z4rqsugYXJomibc1aqLq/HL+Z4jWEbUq16BBvNUQYv1z/p2M0Fpu/fDGNzEGwyikpjo6colKYg==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.41.tgz",
-            "integrity": "sha512-Q1bLTqOeHkhF2VU7B6bwXzVIDI6rtmOnj7nEoElw0vnNxxmcigoFsrNOitGFdiD6tMUCQkmUWDlAjpU2tA4rkw==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.42.tgz",
+            "integrity": "sha512-BiI4v00v2cQmPywE2QA5SzMfHwk1PzF4n4URarLcO2AdguaoMYgAKm09BpvY0uL9W7ILDX4jyku45ibIvDyglw==",
             "cpu": [
                 "x64"
             ],
@@ -606,9 +606,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.41.tgz",
-            "integrity": "sha512-kLWxYlvurXssacmVldjq705GjVxmqWsOHaPL90Fo8a5W9bLCUiSCCpPcnqK2a+lKEhFvLmkUbilYvf8iZxnXfw==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.42.tgz",
+            "integrity": "sha512-Cmk+f9aDczKUNmn6SkQfyb2ZuoOKUiVZ42MP/Cb2BHJqjWLJx474D5CYbMF27jCMXCDOwWPomWvzsPdCufiDHg==",
             "cpu": [
                 "x64"
             ],
@@ -618,9 +618,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.41.tgz",
-            "integrity": "sha512-/ExyNL4CkohKvon3ANA7QZb9OK4CgfsC5ApxlJY0NDtbNwmdHu41oBMTFbADbD1AWpybPJhi3gD/e3Tv1xpBEA==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.42.tgz",
+            "integrity": "sha512-JgRbfgh2kqMkL0EcWPy+wtWtuPHYosnIYX85EE29zZuH0ZklNMcmd9Q1cbDehTG1t7IDMh6LnagTc83M54YegQ==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +630,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.41.tgz",
-            "integrity": "sha512-FpJkp3mGv2jJ5ZmDSU2pGs4zbDbPB81j6ILDcTiX43Uq7vp/0aqZOMzG+xHv/obnM7T72VTE8KrAYFWvm31wPQ==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.42.tgz",
+            "integrity": "sha512-eYtAHv4B9SWCY/3Hbmud4XPyJW8xt1VMqwegdHhUVustJGt8TYljtjZYUOYXdh346wU0vs3d3rehsn9qi7tp5Q==",
             "cpu": [
                 "arm64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.41.tgz",
-            "integrity": "sha512-XzJJIqm1KU+c2FDtQ9XJUIMHc0eAI6159pFYEEXufiWJ3wpLGSYhLT/16CF82tvWV1iZvr8EYE/NJxRWpGIc/Q==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.42.tgz",
+            "integrity": "sha512-/SWkQftlVXG9UWmZLzbfhXMYanf63LSpVDf/L7t/jxFIB51MWrWgPZVzpWbftU1pXSAJchcirrGIPOoR0J4xXA==",
             "cpu": [
                 "x64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.41.tgz",
-            "integrity": "sha512-zqdEIzWS2qtSxqmTCSGw7K+jXVoi4WumKMAhqtdJoyUunQ3IoSBIQp2zS6Pzwmn3vnvBltrvAzyzVUn9VsUmVg==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.42.tgz",
+            "integrity": "sha512-28MNoErwfkE4/Jr6ihS0zC5a0Q2In7ejQjPULgtc2oisaXvUoFt1UevnPIbtShjD7pW38rTr6ZKy3xDKCFlqjQ==",
             "cpu": [
                 "x64"
             ],
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.2.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.2.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.2.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.2.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.1.tgz",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.2.tgz",
             "cpu": [
                 "x64"
             ],
@@ -825,27 +825,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.41",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.41.tgz",
-            "integrity": "sha512-ulgXkhAUyI43T9IFrXaPKJ/gpMk77Lo8ZHC32Zh53AM6C9EfdRlpmkSKR2FDtgUhQCmpD9HqlMeL3SBhfAelSw==",
+            "version": "1.4.42",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.42.tgz",
+            "integrity": "sha512-m8HzgZM8LO+3DYAHaInx+PYy/r+IZCzVVCCqDagY8WPKkdS5vzyyNMwKg+h7zvRnxiiPWynJhUSTx+D41MtKNA==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.41",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.41",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.41",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.41",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.41",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.41",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.41"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.42",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.42",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.42",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.42",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.42",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.42",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.42"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -41,7 +41,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.41",
+        "@vrsen/agentswarm": "1.4.42",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
@@ -52,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.1.1",
-        "@vrsen/openswarm-cli-darwin-x64": "1.1.1",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.1",
-        "@vrsen/openswarm-cli-linux-arm64": "1.1.1",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.1",
-        "@vrsen/openswarm-cli-linux-x64": "1.1.1",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.1",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.1",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.1",
-        "@vrsen/openswarm-cli-windows-arm64": "1.1.1",
-        "@vrsen/openswarm-cli-windows-x64": "1.1.1",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.1"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.1.2",
+        "@vrsen/openswarm-cli-darwin-x64": "1.1.2",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.2",
+        "@vrsen/openswarm-cli-linux-arm64": "1.1.2",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.2",
+        "@vrsen/openswarm-cli-linux-x64": "1.1.2",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.2",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.2",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.2",
+        "@vrsen/openswarm-cli-windows-arm64": "1.1.2",
+        "@vrsen/openswarm-cli-windows-x64": "1.1.2",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.2"
     },
     "engines": {
         "node": ">=20.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.1.1"
+version = "1.1.2"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release picking up AgentSwarm 1.4.42.

- Update checks now compare the OpenSwarm product version instead of the embedded binary version, so bigger releases show the Update Available prompt while patches keep auto-updating quietly, and an equal or lower registry version never triggers.
- When an agency project fails to start, a toast explains that the startup error was added to the message composer with Enter sending it to Build for repair.
- Bump the package, lockfile, Python project, and 12 platform packages to 1.1.2; `@vrsen/agentswarm` pinned to 1.4.42 with real registry records in the lockfile.

Verified locally: launcher smoke passes, document-containment regression test passes, lockfile carries the published 1.4.42 integrity. AgentSwarm 1.4.42 itself shipped with 23 product tests (4 new update-check tests), a real-terminal e2e asserting the startup toast, and full green CI on both PRs.