### PR TITLE
Release OpenSwarm 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@vrsen/openswarm",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@vrsen/agentswarm": "1.4.42",
+                "@vrsen/agentswarm": "1.4.43",
                 "dom-to-pptx": "1.1.5",
                 "patch-package": "^8.0.1",
                 "playwright": "^1.59.1",
@@ -31,18 +31,18 @@
                 "python": ">=3.12"
             },
             "optionalDependencies": {
-                "@vrsen/openswarm-cli-darwin-arm64": "1.1.2",
-                "@vrsen/openswarm-cli-darwin-x64": "1.1.2",
-                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.2",
-                "@vrsen/openswarm-cli-linux-arm64": "1.1.2",
-                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.2",
-                "@vrsen/openswarm-cli-linux-x64": "1.1.2",
-                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.2",
-                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.2",
-                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.2",
-                "@vrsen/openswarm-cli-windows-arm64": "1.1.2",
-                "@vrsen/openswarm-cli-windows-x64": "1.1.2",
-                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.2"
+                "@vrsen/openswarm-cli-darwin-arm64": "1.1.3",
+                "@vrsen/openswarm-cli-darwin-x64": "1.1.3",
+                "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.3",
+                "@vrsen/openswarm-cli-linux-arm64": "1.1.3",
+                "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.3",
+                "@vrsen/openswarm-cli-linux-x64": "1.1.3",
+                "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.3",
+                "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.3",
+                "@vrsen/openswarm-cli-linux-x64-musl": "1.1.3",
+                "@vrsen/openswarm-cli-windows-arm64": "1.1.3",
+                "@vrsen/openswarm-cli-windows-x64": "1.1.3",
+                "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.3"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -510,21 +510,21 @@
             }
         },
         "node_modules/@vrsen/agentswarm": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.42.tgz",
-            "integrity": "sha512-KluvfvHFgepJZFN+83Pi1wmfZ+yBYgdBZjYnk/bVlPTy+yDFPphbMAVijz+O8RMHVS5kir4UOZ0wJtgqjTEjPg==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm/-/agentswarm-1.4.43.tgz",
+            "integrity": "sha512-qdQEryQci9VjoP3OiuCzGdrowUUiV+VET/ZLBP0kqiMm1VdrEYtSZgZrjTc06I6GxeYheKOkMtasHBa13olmrw==",
             "license": "MIT",
             "dependencies": {
-                "agentswarm-cli": "1.4.42"
+                "agentswarm-cli": "1.4.43"
             },
             "bin": {
                 "agentswarm": "bin/agentswarm"
             }
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-arm64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.42.tgz",
-            "integrity": "sha512-m8+Mc9H0xzx214keXh4iE4wsKK6AZg30PvKvK4cDTDAvUTOaoMQMSb5TMhBye18Zs3d0zihe7FdWlQoY0JEtEA==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-arm64/-/agentswarm-cli-darwin-arm64-1.4.43.tgz",
+            "integrity": "sha512-oBQ66p5fg/C3GIII4TD2fMqdDg53fzGc25+lp+Gee5www2xTyVCbbQl4XnigSOPFlB9SiZpctMUc5e2QGRoLKA==",
             "cpu": [
                 "arm64"
             ],
@@ -534,9 +534,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.42.tgz",
-            "integrity": "sha512-CII4p0h/dPexQppMA+ScATtxgu7OtuQDzeY7OhnOpy9bWOcLuaBuQulBvZwFa5FKk61Jh6iKxbIrhTKfh+Fqgw==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64/-/agentswarm-cli-darwin-x64-1.4.43.tgz",
+            "integrity": "sha512-LwNFm/wIjkP61Rj1RGAvpMzLlLQm0AcUml5/Y+sJvjNxMI1UUYsPXAolYJfEr1UaaNQ2Mu1edjM1aMJDZj7N8A==",
             "cpu": [
                 "x64"
             ],
@@ -546,9 +546,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-darwin-x64-baseline": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.42.tgz",
-            "integrity": "sha512-4pPvw79LWuog1MqM/pcJ3EMy5IPYMqf5VlSGL0eZBVjSSZZiWE826OEdWEOI+sqnSWAZ5IoBKrWyXl/VcaqsqA==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-darwin-x64-baseline/-/agentswarm-cli-darwin-x64-baseline-1.4.43.tgz",
+            "integrity": "sha512-XPGhNpOWJYAzj6FIxJ6efm9b67tMX3MKeH7QvErTE29cVSNNgyFxK3LjWvBIlJ1aJNl4SgPK2vYALSS/QnTwSg==",
             "cpu": [
                 "x64"
             ],
@@ -558,9 +558,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.42.tgz",
-            "integrity": "sha512-ag6UGFJXw1yfMjJiaI5/IXmSrh9q8bOro6nwZED8UJkn2eC0EbPVqYkAGlwg2XB+yxFuSMBWifoVYergQt8wBA==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64/-/agentswarm-cli-linux-arm64-1.4.43.tgz",
+            "integrity": "sha512-aleCrhMcYDkzI+2MkNYgt2i7Tgua3DhYOyssxHKKMtkg4WTdafFWEL8kV7R+UXKs8vLiyogycIrAwTeEtvWEIA==",
             "cpu": [
                 "arm64"
             ],
@@ -570,9 +570,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-arm64-musl": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.42.tgz",
-            "integrity": "sha512-9T+6QTNbKFRtdJJJlaDpxcL+bC6ehICfKyClpt62r9TPqTz1xSvc22SCYjAi47/A3zF0GWPy2LuwVnXJ7OZA2w==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-arm64-musl/-/agentswarm-cli-linux-arm64-musl-1.4.43.tgz",
+            "integrity": "sha512-Lw4/hC8gCM9XysuFQ2unzqH6AwYKftr6kxuB5ctSOFdTvIfii7+8M3unMnopodqZ9ejGo78A/EUADMAKqrueWg==",
             "cpu": [
                 "arm64"
             ],
@@ -582,9 +582,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.42.tgz",
-            "integrity": "sha512-8/pYEr+kETY6z4rqsugYXJomibc1aqLq/HL+Z4jWEbUq16BBvNUQYv1z/p2M0Fpu/fDGNzEGwyikpjo6colKYg==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64/-/agentswarm-cli-linux-x64-1.4.43.tgz",
+            "integrity": "sha512-GKbHaDScdxsBIsovXyhGl/obMUA1Q3iV7A0C/adg9SNw/RccN69Hf0EmLB5v9w9hwyd65jNg8c90/FJdS4XpJA==",
             "cpu": [
                 "x64"
             ],
@@ -594,9 +594,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.42.tgz",
-            "integrity": "sha512-BiI4v00v2cQmPywE2QA5SzMfHwk1PzF4n4URarLcO2AdguaoMYgAKm09BpvY0uL9W7ILDX4jyku45ibIvDyglw==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline/-/agentswarm-cli-linux-x64-baseline-1.4.43.tgz",
+            "integrity": "sha512-CloVFfWr+1CadVZN2+uL2SJVSysMW980Zg/L2mDyRoIo2ErYhiXRNrMFY06SxVeci8XRCNL1igJ5Ajnhqc3wkw==",
             "cpu": [
                 "x64"
             ],
@@ -606,9 +606,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.42.tgz",
-            "integrity": "sha512-Cmk+f9aDczKUNmn6SkQfyb2ZuoOKUiVZ42MP/Cb2BHJqjWLJx474D5CYbMF27jCMXCDOwWPomWvzsPdCufiDHg==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-baseline-musl/-/agentswarm-cli-linux-x64-baseline-musl-1.4.43.tgz",
+            "integrity": "sha512-LuHmxxC+s1ZJw+Zp9kn44rIQYoHIys1wHQsWb6OFcDlEQrve4Zs6VSzdDFlqP97DRFOaV4why6EniUF/GYuxVQ==",
             "cpu": [
                 "x64"
             ],
@@ -618,9 +618,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-linux-x64-musl": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.42.tgz",
-            "integrity": "sha512-JgRbfgh2kqMkL0EcWPy+wtWtuPHYosnIYX85EE29zZuH0ZklNMcmd9Q1cbDehTG1t7IDMh6LnagTc83M54YegQ==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-linux-x64-musl/-/agentswarm-cli-linux-x64-musl-1.4.43.tgz",
+            "integrity": "sha512-yxQefv5RTiUZQ8OANdWn9iGXZ/6LuXUB8B002ZdYHnHvzScpxKDT1B2CUoobg/RVpFfqf0qY4oHL2pRnKEFgXg==",
             "cpu": [
                 "x64"
             ],
@@ -630,9 +630,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-arm64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.42.tgz",
-            "integrity": "sha512-eYtAHv4B9SWCY/3Hbmud4XPyJW8xt1VMqwegdHhUVustJGt8TYljtjZYUOYXdh346wU0vs3d3rehsn9qi7tp5Q==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-arm64/-/agentswarm-cli-windows-arm64-1.4.43.tgz",
+            "integrity": "sha512-ShFkaBnaMGiFbP5ILVzPMgzXkdjalO1JiWfAqg/jlEn/+uP9GjMAGfph+DdJqOHqQ1bDCDWjj5XUIp6WhQtyfg==",
             "cpu": [
                 "arm64"
             ],
@@ -642,9 +642,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.42.tgz",
-            "integrity": "sha512-/SWkQftlVXG9UWmZLzbfhXMYanf63LSpVDf/L7t/jxFIB51MWrWgPZVzpWbftU1pXSAJchcirrGIPOoR0J4xXA==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64/-/agentswarm-cli-windows-x64-1.4.43.tgz",
+            "integrity": "sha512-TWewRh33TMMQ7kMo4CxUPPhCQJgpRP+R7M6Cim5qKiilxJdM3uo5mpFQWHJsEAXXJ1ZwJX4L4MfFB/8maq0zeg==",
             "cpu": [
                 "x64"
             ],
@@ -654,9 +654,9 @@
             ]
         },
         "node_modules/@vrsen/agentswarm-cli-windows-x64-baseline": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.42.tgz",
-            "integrity": "sha512-28MNoErwfkE4/Jr6ihS0zC5a0Q2In7ejQjPULgtc2oisaXvUoFt1UevnPIbtShjD7pW38rTr6ZKy3xDKCFlqjQ==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/@vrsen/agentswarm-cli-windows-x64-baseline/-/agentswarm-cli-windows-x64-baseline-1.4.43.tgz",
+            "integrity": "sha512-zPpwXhwFT9S7eLZxVnA+VPaPqPAQYM7BgCIoQGXtHr0yh7cuQSVA+PJjZETU6mmIATwXXpBYb7QozwO4FtFS4A==",
             "cpu": [
                 "x64"
             ],
@@ -666,8 +666,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-arm64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-arm64/-/openswarm-cli-darwin-arm64-1.1.3.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -678,8 +678,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64/-/openswarm-cli-darwin-x64-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -690,8 +690,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-darwin-x64-baseline": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-darwin-x64-baseline/-/openswarm-cli-darwin-x64-baseline-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -702,8 +702,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64/-/openswarm-cli-linux-arm64-1.1.3.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -714,8 +714,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-arm64-musl": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-arm64-musl/-/openswarm-cli-linux-arm64-musl-1.1.3.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -726,8 +726,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64/-/openswarm-cli-linux-x64-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -738,8 +738,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline/-/openswarm-cli-linux-x64-baseline-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -750,8 +750,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-baseline-musl": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-baseline-musl/-/openswarm-cli-linux-x64-baseline-musl-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -762,8 +762,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-linux-x64-musl": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-linux-x64-musl/-/openswarm-cli-linux-x64-musl-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -774,8 +774,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-arm64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-arm64/-/openswarm-cli-windows-arm64-1.1.3.tgz",
             "cpu": [
                 "arm64"
             ],
@@ -786,8 +786,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64/-/openswarm-cli-windows-x64-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -798,8 +798,8 @@
             ]
         },
         "node_modules/@vrsen/openswarm-cli-windows-x64-baseline": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.2.tgz",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@vrsen/openswarm-cli-windows-x64-baseline/-/openswarm-cli-windows-x64-baseline-1.1.3.tgz",
             "cpu": [
                 "x64"
             ],
@@ -825,27 +825,27 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/agentswarm-cli": {
-            "version": "1.4.42",
-            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.42.tgz",
-            "integrity": "sha512-m8HzgZM8LO+3DYAHaInx+PYy/r+IZCzVVCCqDagY8WPKkdS5vzyyNMwKg+h7zvRnxiiPWynJhUSTx+D41MtKNA==",
+            "version": "1.4.43",
+            "resolved": "https://registry.npmjs.org/agentswarm-cli/-/agentswarm-cli-1.4.43.tgz",
+            "integrity": "sha512-IlK5+DNkgEpRYf0fZfX2XhsXOnj+n2X9ZlNpV3pouk3dNemSLV6CTzQioJeOe4E2YmX9GSiJUUKAMebndHgW7g==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agentswarm": "bin/agentswarm"
             },
             "optionalDependencies": {
-                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.42",
-                "@vrsen/agentswarm-cli-darwin-x64": "1.4.42",
-                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-arm64": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-x64": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.42",
-                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.42",
-                "@vrsen/agentswarm-cli-windows-arm64": "1.4.42",
-                "@vrsen/agentswarm-cli-windows-x64": "1.4.42",
-                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.42"
+                "@vrsen/agentswarm-cli-darwin-arm64": "1.4.43",
+                "@vrsen/agentswarm-cli-darwin-x64": "1.4.43",
+                "@vrsen/agentswarm-cli-darwin-x64-baseline": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-arm64": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-arm64-musl": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-x64": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-x64-baseline": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-x64-baseline-musl": "1.4.43",
+                "@vrsen/agentswarm-cli-linux-x64-musl": "1.4.43",
+                "@vrsen/agentswarm-cli-windows-arm64": "1.4.43",
+                "@vrsen/agentswarm-cli-windows-x64": "1.4.43",
+                "@vrsen/agentswarm-cli-windows-x64-baseline": "1.4.43"
             }
         },
         "node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vrsen/openswarm",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "An open-source multi-agent AI team built on Agency Swarm",
     "license": "MIT",
     "publishConfig": {
@@ -41,7 +41,7 @@
         "postinstall": "node -e \"const fs=require('fs');const path=require('path');const cp=require('child_process');const pkg=__dirname;const patchTarget=path.join(pkg,'node_modules','dom-to-pptx');const patchCli=path.join(pkg,'node_modules','patch-package','index.js');if(fs.existsSync(patchTarget)&&fs.existsSync(patchCli)){cp.execFileSync(process.execPath,[patchCli],{cwd:pkg,stdio:'inherit'});}try{fs.chmodSync(path.join(pkg,'bin','openswarm'),0o755)}catch(e){}\""
     },
     "dependencies": {
-        "@vrsen/agentswarm": "1.4.42",
+        "@vrsen/agentswarm": "1.4.43",
         "dom-to-pptx": "1.1.5",
         "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
@@ -52,18 +52,18 @@
         "sharp": "^0.33.0"
     },
     "optionalDependencies": {
-        "@vrsen/openswarm-cli-darwin-arm64": "1.1.2",
-        "@vrsen/openswarm-cli-darwin-x64": "1.1.2",
-        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.2",
-        "@vrsen/openswarm-cli-linux-arm64": "1.1.2",
-        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.2",
-        "@vrsen/openswarm-cli-linux-x64": "1.1.2",
-        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.2",
-        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.2",
-        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.2",
-        "@vrsen/openswarm-cli-windows-arm64": "1.1.2",
-        "@vrsen/openswarm-cli-windows-x64": "1.1.2",
-        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.2"
+        "@vrsen/openswarm-cli-darwin-arm64": "1.1.3",
+        "@vrsen/openswarm-cli-darwin-x64": "1.1.3",
+        "@vrsen/openswarm-cli-darwin-x64-baseline": "1.1.3",
+        "@vrsen/openswarm-cli-linux-arm64": "1.1.3",
+        "@vrsen/openswarm-cli-linux-arm64-musl": "1.1.3",
+        "@vrsen/openswarm-cli-linux-x64": "1.1.3",
+        "@vrsen/openswarm-cli-linux-x64-baseline": "1.1.3",
+        "@vrsen/openswarm-cli-linux-x64-baseline-musl": "1.1.3",
+        "@vrsen/openswarm-cli-linux-x64-musl": "1.1.3",
+        "@vrsen/openswarm-cli-windows-arm64": "1.1.3",
+        "@vrsen/openswarm-cli-windows-x64": "1.1.3",
+        "@vrsen/openswarm-cli-windows-x64-baseline": "1.1.3"
     },
     "engines": {
         "node": ">=20.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "open-swarm"
 description = "An open-source multi-agent AI team built on Agency Swarm and the OpenAI Agents SDK"
-version = "1.1.2"
+version = "1.1.3"
 license = { text = "MIT" }
 keywords = ["agency-swarm", "openai", "multi-agent", "open-source", "openswarm"]
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release: pin AgentSwarm 1.4.43 (Build→Plan switching for unclear swarm work) and ship the Composio sessions fix already on main (#79). Bumps package, lockfile, Python project, and 12 platform packages to 1.1.3.

Verified: launcher smoke passes; lockfile carries the published 1.4.43 integrity; the Build→Plan flow was proven in a live terminal session with a real model (dialog rendered, Yes switched the session to Plan).