### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ ANTHROPIC_API_KEY=
 # Google Gemini — set this if using Google as your primary provider.
 GOOGLE_API_KEY=
 
+# OrcaRouter — OpenAI-compatible AI gateway. Set this if using OrcaRouter
+# as your primary provider, then set DEFAULT_MODEL to an orcarouter/<model>
+# model (e.g. orcarouter/gpt-5.6-luna). Get a key at https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+
 
 # ── Model selection ───────────────────────────
 
@@ -24,6 +29,7 @@ GOOGLE_API_KEY=
 # OpenAI example:   DEFAULT_MODEL=gpt-5.4
 # Anthropic example: DEFAULT_MODEL=litellm/claude-sonnet-4-6
 # Google example:   DEFAULT_MODEL=litellm/gemini/gemini-3-flash
+# OrcaRouter example: DEFAULT_MODEL=orcarouter/gpt-5.6-luna
 DEFAULT_MODEL=
 
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ The setup wizard walks you through everything, but you'll need at least one of t
 - `OPENAI_API_KEY` - For GPT 5.5 and Sora video generation
 - `ANTHROPIC_API_KEY` - For Claude models
 
+**Alternative primary provider:**
+
+- `ORCAROUTER_API_KEY` - Route all agents through the [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible gateway instead. Set `DEFAULT_MODEL=orcarouter/<model>` (e.g. `orcarouter/gpt-5.6-luna`). Get a key at https://www.orcarouter.ai
+
 **Optional superpowers:**
 
 - `COMPOSIO_API_KEY` - Unlock 10,000+ integrations (Gmail, Slack, GitHub, etc.)

--- a/config.py
+++ b/config.py
@@ -1,6 +1,9 @@
 """Shared model configuration helpers — read by all agents at startup."""
 import os
 
+_ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+_ORCAROUTER_PREFIX = "orcarouter/"
+
 
 def get_default_model(fallback: str = "gpt-5.4"):
     """Return the configured default model for standard agents."""
@@ -13,9 +16,15 @@ def is_openai_provider() -> bool:
 
     OpenAI model IDs never contain a slash (e.g. 'gpt-5.4', 'o3').
     Any 'provider/model' string (e.g. 'anthropic/claude-sonnet-4-6',
-    'litellm/gemini/gemini-3-flash') is treated as a LiteLLM-routed model.
+    'litellm/gemini/gemini-3-flash', 'orcarouter/gpt-5.6-luna') is
+    treated as a LiteLLM-routed model.
     """
     return "/" not in os.getenv("DEFAULT_MODEL", "")
+
+
+def is_orcarouter_provider() -> bool:
+    """Return True when the configured provider is OrcaRouter."""
+    return os.getenv("DEFAULT_MODEL", "").startswith(_ORCAROUTER_PREFIX)
 
 
 def _resolve(model: str):
@@ -26,9 +35,29 @@ def _resolve(model: str):
     """
     if "/" not in model:
         return model
+    if model.startswith(_ORCAROUTER_PREFIX):
+        return _make_orcarouter_model(model[len(_ORCAROUTER_PREFIX):])
     bare = model[len("litellm/"):] if model.startswith("litellm/") else model
     try:
         from agency_swarm import LitellmModel  # noqa: PLC0415
         return LitellmModel(model=bare)
     except ImportError:
         return model
+
+
+def _make_orcarouter_model(model: str):
+    """Build a LiteLLM model pinned to the OrcaRouter gateway.
+
+    OrcaRouter has its own credential namespace, so it is wired to the
+    ORCAROUTER_API_KEY add-on instead of the OpenAI/Anthropic keys that
+    LiteLLM would otherwise pick up from the environment.
+    """
+    try:
+        from agency_swarm import LitellmModel  # noqa: PLC0415
+        return LitellmModel(
+            model=model,
+            api_key=os.getenv("ORCAROUTER_API_KEY"),
+            base_url=_ORCAROUTER_BASE_URL,
+        )
+    except ImportError:
+        return f"{_ORCAROUTER_PREFIX}{model}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ORCAROUTER_URL = "https://api.orcarouter.ai/v1"
+
+
+class FakeLitellmModel:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def install_agency_swarm_stub() -> None:
+    """Stub the agency_swarm package so config can import LitellmModel."""
+    agency = types.ModuleType("agency_swarm")
+    agency.LitellmModel = FakeLitellmModel
+    sys.modules["agency_swarm"] = agency
+
+
+def load_config():
+    spec = importlib.util.spec_from_file_location("config", ROOT / "config.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["config"] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class ConfigProviderRoutingTests(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("DEFAULT_MODEL", None)
+        os.environ.pop("ORCAROUTER_API_KEY", None)
+        sys.modules.pop("config", None)
+        install_agency_swarm_stub()
+
+    def test_bare_model_passes_through_unchanged(self):
+        config = load_config()
+        os.environ["DEFAULT_MODEL"] = "gpt-5.4"
+
+        self.assertEqual(config.get_default_model(), "gpt-5.4")
+        self.assertTrue(config.is_openai_provider())
+        self.assertFalse(config.is_orcarouter_provider())
+
+    def test_orcarouter_model_is_routed_to_litellm_with_gateway_credentials(self):
+        config = load_config()
+        os.environ["DEFAULT_MODEL"] = "orcarouter/gpt-5.6-luna"
+        os.environ["ORCAROUTER_API_KEY"] = "orc-test-key"
+
+        model = config.get_default_model()
+
+        self.assertIsInstance(model, FakeLitellmModel)
+        self.assertEqual(model.model, "gpt-5.6-luna")
+        self.assertEqual(model.api_key, "orc-test-key")
+        self.assertEqual(model.base_url, ORCAROUTER_URL)
+        self.assertFalse(config.is_openai_provider())
+        self.assertTrue(config.is_orcarouter_provider())
+
+    def test_litellm_prefixed_model_preserves_legacy_behavior(self):
+        config = load_config()
+        os.environ["DEFAULT_MODEL"] = "litellm/anthropic/claude-sonnet-4-6"
+
+        model = config.get_default_model()
+
+        self.assertIsInstance(model, FakeLitellmModel)
+        self.assertEqual(model.model, "anthropic/claude-sonnet-4-6")
+        self.assertNotIn("base_url", model.kwargs)
+
+    def test_other_provider_model_still_routes_through_litellm(self):
+        config = load_config()
+        os.environ["DEFAULT_MODEL"] = "anthropic/claude-sonnet-4-6"
+
+        model = config.get_default_model()
+
+        self.assertIsInstance(model, FakeLitellmModel)
+        self.assertEqual(model.model, "anthropic/claude-sonnet-4-6")
+        self.assertNotIn("api_key", model.kwargs)
+        self.assertNotIn("base_url", model.kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Add OrcaRouter as a first-class provider so the swarm can run on the OrcaRouter OpenAI-compatible AI gateway. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means OpenSwarm users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `config.py`: resolve `orcarouter/<model>` through LiteLLM like the existing `litellm/` provider pattern (used today for Anthropic and Gemini), but bind `ORCAROUTER_API_KEY` and the `https://api.orcarouter.ai/v1` base URL explicitly, since OrcaRouter has its own credential namespace. Non-OrcaRouter resolution is unchanged. Also adds `is_orcarouter_provider()` for agent settings that branch on the provider.
- `.env.example`: document `ORCAROUTER_API_KEY` under the provider section and add a `DEFAULT_MODEL=orcarouter/<model>` example.
- `README.md`: list `ORCAROUTER_API_KEY` as an alternative primary provider.
- `tests/test_config.py`: unit tests covering bare-model passthrough, `orcarouter/` routing to LiteLLM with the gateway credentials, and unchanged `litellm/` / bare `provider/model` behavior.

## Checks

- `python -m pytest tests/` — 13 passed, 4 subtests passed (full suite, including the pre-existing Slides model routing tests)
- `python -m py_compile config.py`
- Live call through the new `orcarouter/` route (`config.get_default_model()` with `DEFAULT_MODEL=orcarouter/gpt-5.6-luna`) hit `https://api.orcarouter.ai/v1` and returned a completion.

Questions or feedback welcome — Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
